### PR TITLE
[#61] retain block order in config

### DIFF
--- a/orebfuscator-plugin/src/main/java/net/imprex/orebfuscator/config/OrebfuscatorProximityConfig.java
+++ b/orebfuscator-plugin/src/main/java/net/imprex/orebfuscator/config/OrebfuscatorProximityConfig.java
@@ -1,7 +1,7 @@
 package net.imprex.orebfuscator.config;
 
 import java.util.ArrayList;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -23,9 +23,9 @@ public class OrebfuscatorProximityConfig implements ProximityConfig {
 	private int distanceSquared;
 	private boolean useFastGazeCheck;
 
-	private Map<Material, Short> hiddenBlocks = new HashMap<>();
+	private Map<Material, Short> hiddenBlocks = new LinkedHashMap<>();
 
-	private Map<Material, Integer> randomBlocks = new HashMap<>();
+	private Map<Material, Integer> randomBlocks = new LinkedHashMap<>();
 	private final List<Integer> randomBlockIds = new ArrayList<>();
 	private WeightedRandom<Integer> randomMaterials = new WeightedRandom<>();
 

--- a/orebfuscator-plugin/src/main/java/net/imprex/orebfuscator/config/OrebfuscatorWorldConfig.java
+++ b/orebfuscator-plugin/src/main/java/net/imprex/orebfuscator/config/OrebfuscatorWorldConfig.java
@@ -1,8 +1,8 @@
 package net.imprex.orebfuscator.config;
 
 import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -20,9 +20,9 @@ public class OrebfuscatorWorldConfig implements WorldConfig {
 
 	private boolean enabled;
 	private final List<String> worlds = new ArrayList<>();
-	private final Set<Material> hiddenBlocks = new HashSet<>();
+	private final Set<Material> hiddenBlocks = new LinkedHashSet<>();
 
-	private final Map<Material, Integer> randomBlocks = new HashMap<>();
+	private final Map<Material, Integer> randomBlocks = new LinkedHashMap<>();
 	private final List<Integer> randomBlockIds = new ArrayList<>();
 	private final WeightedRandom<Integer> randomMaterials = new WeightedRandom<>();
 


### PR DESCRIPTION
## Description
Retain block order of `hiddenBlocks` and `randomBlocks` in the config.yml after saving the config

## Related Issue
#61 

## Motivation and Context
> In the default config.yml file created by the plugin, hiddenBlocks and randomBlocks are in an arbitrary order. This makes it difficult for server owners to compare config files to see what has changed when a new version is released.

## How Has This Been Tested?
manually tested

## Types of Changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
