### PR TITLE
[#67] remove cache path restriction

### DIFF
--- a/orebfuscator-plugin/src/main/java/net/imprex/orebfuscator/config/OrebfuscatorCacheConfig.java
+++ b/orebfuscator-plugin/src/main/java/net/imprex/orebfuscator/config/OrebfuscatorCacheConfig.java
@@ -4,8 +4,8 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.concurrent.TimeUnit;
-import java.util.logging.Level;
 
 import org.bukkit.Bukkit;
 import org.bukkit.configuration.ConfigurationSection;
@@ -44,8 +44,7 @@ public class OrebfuscatorCacheConfig implements CacheConfig {
 
 	public void deserialize(ConfigurationSection section) {
 		section.set("enabled", this.enabled);
-		section.set("baseDirectory", Bukkit.getWorldContainer().toPath().toAbsolutePath().normalize()
-				.relativize(this.baseDirectory).normalize().toString());
+		section.set("baseDirectory", this.baseDirectory.toString());
 
 		section.set("maximumOpenRegionFiles", this.maximumOpenRegionFiles);
 		section.set("deleteRegionFilesAfterAccess", this.deleteRegionFilesAfterAccess);
@@ -62,19 +61,16 @@ public class OrebfuscatorCacheConfig implements CacheConfig {
 		String baseDirectory = section.getString("baseDirectory", defaultPath);
 
 		try {
-			this.baseDirectory = worldPath.resolve(baseDirectory).normalize();
+			this.baseDirectory = Paths.get(baseDirectory).normalize();
 		} catch (InvalidPathException e) {
-			OFCLogger.log(Level.WARNING,
-					"config path '" + section.getCurrentPath() + ".baseDirectory' contains malformed path '"
-							+ baseDirectory + "', using default path '" + defaultPath + "'");
+			OFCLogger.warn("config path '" + section.getCurrentPath() + ".baseDirectory' contains malformed path '"
+					+ baseDirectory + "', using default path '" + defaultPath + "'");
 			this.baseDirectory = worldPath.resolve(defaultPath).normalize();
 		}
 
 		if (!this.baseDirectory.startsWith(worldPath)) {
-			OFCLogger.log(Level.WARNING,
-					"config path '" + section.getCurrentPath() + ".baseDirectory' is no child directory of '"
-							+ worldPath + "', using default path: '" + defaultPath + "'");
-			this.baseDirectory = worldPath.resolve(defaultPath).normalize();
+			OFCLogger.warn("config path '" + section.getCurrentPath() + ".baseDirectory' is no child directory of '"
+					+ worldPath + "'");
 		}
 
 		if (this.enabled()) {


### PR DESCRIPTION
## Description
Remove the cache path restriction which forced the path to be a subpath of the worlddir.

## Related Issue
#67 

## Motivation and Context
> Previously > (Orebfuscator4) I could move it to RAM-disk, but now I can't.

## How Has This Been Tested?
manually tested

## Types of Changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
