### PR TITLE
[#45] Fix cache invalidation after block update

### DIFF
--- a/orebfuscator-plugin/src/main/java/net/imprex/orebfuscator/obfuscation/DeobfuscationListener.java
+++ b/orebfuscator-plugin/src/main/java/net/imprex/orebfuscator/obfuscation/DeobfuscationListener.java
@@ -78,13 +78,13 @@ public class DeobfuscationListener implements Listener {
 				BlockStateHolder blockState = NmsInstance.getBlockState(world, x, y, z);
 				if (blockState != null) {
 					getAdjacentBlocks(updateBlocks, world, blockMask, blockState, updateRadius);
-					invalidChunks.add(new ChunkPosition(world, x >> 4, z >> 4));
 				}
 			}
 		}
 
 		for (BlockStateHolder blockState : updateBlocks) {
 			blockState.notifyBlockChange();
+			invalidChunks.add(new ChunkPosition(world, blockState.getX() >> 4, blockState.getZ() >> 4));
 		}
 
 		if (!invalidChunks.isEmpty() && config.cache().enabled()) {


### PR DESCRIPTION
## Description
Fixes block update detection to invalidate the correct chached chunks

## Related Issue
closes #45

## Motivation and Context
When a player breaks blocks next to a chunk border the other chunk doesn't get invalidated in cache and keeps an invalid state.

## How Has This Been Tested?
Successfully tested with spigot 1.16.4

## Types of Changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
