### PR TITLE
[#76] Add "/version" to bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -5,9 +5,11 @@ about: For reporting code or game bugs produced by ofc!
 ---
 
 **Please fill out the following information:**
-* Server Version: 
-* Orebfuscator Version: 
-* Protocollib Version: 
+
+* Server Version: <!-- use "/version" command for server version -->
+* Orebfuscator Version: <!-- use "/version Orebfuscator" command for Orebfuscator version -->
+* Protocollib Version: <!-- use "/version ProtocolLib" command for ProtocolLib version -->
 
 **Describe the bug**
-Describe the bug clearly and how to produce it
+
+<!-- Describe the bug clearly and how to produce it -->


### PR DESCRIPTION
## Description
Add the "/version" command to the bug report template for more specific versions

## Related Issue
closes #76 

## Motivation and Context
Some issue have very vague version

## How Has This Been Tested?

## Types of Changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
