### PR TITLE
[#85] Add API for deobfuscation

### DIFF
--- a/orebfuscator-api-example/pom.xml
+++ b/orebfuscator-api-example/pom.xml
@@ -1,0 +1,29 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	
+	<parent>
+		<groupId>net.imprex</groupId>
+		<artifactId>orebfuscator</artifactId>
+		<version>${revision}</version>
+	</parent>
+	
+	<artifactId>orebfuscator-api-example</artifactId>
+	<packaging>jar</packaging>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.bukkit</groupId>
+			<artifactId>bukkit</artifactId>
+			<version>${dependency.bukkit.version}</version>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>net.imprex</groupId>
+			<artifactId>orebfuscator-api</artifactId>
+			<version>${revision}</version>
+			<scope>compile</scope>
+		</dependency>
+	</dependencies>
+</project>

--- a/orebfuscator-api-example/src/main/java/net/imprex/api/example/Example.java
+++ b/orebfuscator-api-example/src/main/java/net/imprex/api/example/Example.java
@@ -1,0 +1,77 @@
+package net.imprex.api.example;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.logging.Logger;
+
+import org.bukkit.Bukkit;
+import org.bukkit.Material;
+import org.bukkit.block.Block;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.block.Action;
+import org.bukkit.event.player.PlayerInteractEvent;
+import org.bukkit.inventory.EquipmentSlot;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.plugin.ServicesManager;
+import org.bukkit.plugin.java.JavaPlugin;
+
+import net.imprex.orebfuscator.api.OrebfuscatorService;
+
+public class Example extends JavaPlugin implements Listener {
+
+	private static final Logger LOGGER = Logger.getLogger("bukkit.orebfuscator-api-example");
+
+	private OrebfuscatorService orebfuscatorService;
+
+	@Override
+	public void onEnable() {
+		ServicesManager serviceManager = getServer().getServicesManager();
+		if (!serviceManager.isProvidedFor(OrebfuscatorService.class)) {
+			LOGGER.severe("OrebfuscatorService not found! Plugin cannot be enabled.");
+			return;
+		}
+
+		this.orebfuscatorService = serviceManager.load(OrebfuscatorService.class);
+		Bukkit.getPluginManager().registerEvents(this, this);
+	}
+
+	@EventHandler
+	public void onPlayerInteract(PlayerInteractEvent event) {
+		ItemStack item = event.getItem();
+		if (event.getAction() == Action.RIGHT_CLICK_BLOCK && item != null && event.getHand() == EquipmentSlot.HAND) {
+			Block block = event.getClickedBlock();
+
+			if (item.getType() == Material.DIAMOND_PICKAXE) {
+				List<Block> blocks = this.getBlocks(block, 2);
+				this.orebfuscatorService.deobfuscate(blocks);
+				blocks.forEach(b -> b.setType(Material.AIR));
+				event.setCancelled(true);
+			} else if (item.getType() == Material.WOODEN_PICKAXE) {
+				this.orebfuscatorService.deobfuscate(Arrays.asList(block));
+				block.setType(Material.AIR);
+				event.setCancelled(true);
+			}
+		}
+	}
+
+	private List<Block> getBlocks(Block origin, int size) {
+		List<Block> blocks = new ArrayList<Block>();
+
+		blocks.add(origin);
+
+		for (int x = -size; x <= size; x++) {
+			for (int y = -size; y <= size; y++) {
+				for (int z = -size; z <= size; z++) {
+					Block relative = origin.getRelative(x, y, z);
+					if (!relative.getType().isAir()) {
+						blocks.add(relative);
+					}
+				}
+			}
+		}
+
+		return blocks;
+	}
+}

--- a/orebfuscator-api-example/src/main/java/net/imprex/api/example/Example.java
+++ b/orebfuscator-api-example/src/main/java/net/imprex/api/example/Example.java
@@ -45,12 +45,12 @@ public class Example extends JavaPlugin implements Listener {
 
 			if (item.getType() == Material.DIAMOND_PICKAXE) {
 				List<Block> blocks = this.getBlocks(block, 2);
-				this.orebfuscatorService.deobfuscate(blocks);
 				blocks.forEach(b -> b.setType(Material.AIR));
+				this.orebfuscatorService.deobfuscate(blocks);
 				event.setCancelled(true);
 			} else if (item.getType() == Material.WOODEN_PICKAXE) {
-				this.orebfuscatorService.deobfuscate(Arrays.asList(block));
 				block.setType(Material.AIR);
+				this.orebfuscatorService.deobfuscate(Arrays.asList(block));
 				event.setCancelled(true);
 			}
 		}

--- a/orebfuscator-api-example/src/main/resources/plugin.yml
+++ b/orebfuscator-api-example/src/main/resources/plugin.yml
@@ -1,0 +1,13 @@
+api-version: 1.13
+
+name: orebfuscator-api-example
+version: ${project.version}
+
+main: net.imprex.api.example.Example
+
+author: Ingrim4
+
+depend: [Orebfuscator]
+loadbefore: [Orebfuscator]
+
+description: 'orebfuscator api example project'

--- a/orebfuscator-api/pom.xml
+++ b/orebfuscator-api/pom.xml
@@ -1,0 +1,23 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>net.imprex</groupId>
+		<artifactId>orebfuscator</artifactId>
+		<version>${revision}</version>
+	</parent>
+
+	<artifactId>orebfuscator-api</artifactId>
+	<packaging>jar</packaging>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.bukkit</groupId>
+			<artifactId>bukkit</artifactId>
+			<version>${dependency.bukkit.version}</version>
+			<scope>provided</scope>
+		</dependency>
+	</dependencies>
+</project>

--- a/orebfuscator-api/src/main/java/net/imprex/orebfuscator/api/OrebfuscatorService.java
+++ b/orebfuscator-api/src/main/java/net/imprex/orebfuscator/api/OrebfuscatorService.java
@@ -14,8 +14,9 @@ import org.bukkit.block.Block;
 public interface OrebfuscatorService {
 
 	/**
-	 * Deobfuscates a list of blocks.
-	 * All blocks are expected to be located in the same world and non air.
+	 * Deobfuscates a list of blocks. All blocks are expected to be located in the
+	 * same world and non air. This means this method should be called before the
+	 * actual block update happens.
 	 * 
 	 * @param blocks list of blocks to deobfuscate
 	 */

--- a/orebfuscator-api/src/main/java/net/imprex/orebfuscator/api/OrebfuscatorService.java
+++ b/orebfuscator-api/src/main/java/net/imprex/orebfuscator/api/OrebfuscatorService.java
@@ -1,0 +1,23 @@
+package net.imprex.orebfuscator.api;
+
+import java.util.Collection;
+
+import org.bukkit.block.Block;
+
+/**
+ * <p>Service that gives access to some of Orebfuscators internal methods. Use with caution.</p>
+ * 
+ * <p>All calls to this service are expected to originate from the servers main-thread.</p>
+ * 
+ * @since 5.2.0
+ */
+public interface OrebfuscatorService {
+
+	/**
+	 * Deobfuscates a list of blocks.
+	 * All blocks are expected to be located in the same world and non air.
+	 * 
+	 * @param blocks list of blocks to deobfuscate
+	 */
+	void deobfuscate(Collection<? extends Block> blocks);
+}

--- a/orebfuscator-api/src/main/java/net/imprex/orebfuscator/api/OrebfuscatorService.java
+++ b/orebfuscator-api/src/main/java/net/imprex/orebfuscator/api/OrebfuscatorService.java
@@ -5,9 +5,15 @@ import java.util.Collection;
 import org.bukkit.block.Block;
 
 /**
- * <p>Service that gives access to some of Orebfuscators internal methods. Use with caution.</p>
+ * <p>
+ * Service that gives access to some of Orebfuscators internal methods. Use with
+ * caution.
+ * </p>
  * 
- * <p>All calls to this service are expected to originate from the servers main-thread.</p>
+ * <p>
+ * All calls to this service are expected to originate from the servers
+ * main-thread.
+ * </p>
  * 
  * @since 5.2.0
  */
@@ -15,8 +21,7 @@ public interface OrebfuscatorService {
 
 	/**
 	 * Deobfuscates a list of blocks. All blocks are expected to be located in the
-	 * same world and non air. This means this method should be called before the
-	 * actual block update happens.
+	 * same world. It is recommended to call this method after the block update.
 	 * 
 	 * @param blocks list of blocks to deobfuscate
 	 */

--- a/orebfuscator-common/src/main/java/net/imprex/orebfuscator/config/BlockMask.java
+++ b/orebfuscator-common/src/main/java/net/imprex/orebfuscator/config/BlockMask.java
@@ -11,24 +11,24 @@ public interface BlockMask {
 		return (mask & 0x7F) == 0;
 	}
 
-	public static boolean isSet(int mask, int flag) {
+	public static boolean isBitSet(int mask, int flag) {
 		return (mask & flag) != 0;
 	}
 
-	public static boolean isObfuscateSet(int mask) {
-		return isSet(mask, FLAG_OBFUSCATE);
+	public static boolean isObfuscateBitSet(int mask) {
+		return isBitSet(mask, FLAG_OBFUSCATE);
 	}
 
-	public static boolean isTileEntitySet(int mask) {
-		return isSet(mask, FLAG_TILE_ENTITY);
+	public static boolean isTileEntityBitSet(int mask) {
+		return isBitSet(mask, FLAG_TILE_ENTITY);
 	}
 
-	public static boolean isProximitySet(int mask) {
-		return isSet(mask, FLAG_PROXIMITY);
+	public static boolean isProximityBitSet(int mask) {
+		return isBitSet(mask, FLAG_PROXIMITY);
 	}
 
-	public static boolean isUseBlockBelowSet(int mask) {
-		return isSet(mask, FLAG_USE_BLOCK_BELOW);
+	public static boolean isUseBlockBelowBitSet(int mask) {
+		return isBitSet(mask, FLAG_USE_BLOCK_BELOW);
 	}
 
 	int mask(int blockId);

--- a/orebfuscator-common/src/main/java/net/imprex/orebfuscator/util/BlockPos.java
+++ b/orebfuscator-common/src/main/java/net/imprex/orebfuscator/util/BlockPos.java
@@ -1,5 +1,7 @@
 package net.imprex.orebfuscator.util;
 
+import org.bukkit.World;
+
 public class BlockPos {
 
 	private static final int bitsPerX = 26;
@@ -22,6 +24,10 @@ public class BlockPos {
 		this.x = x;
 		this.y = y;
 		this.z = z;
+	}
+
+	public ChunkPosition toChunkPosition(World world) {
+		return new ChunkPosition(world, this.x >> 4, this.z >> 4);
 	}
 
 	public long toLong() {

--- a/orebfuscator-nms/orebfuscator-nms-api/src/main/java/net/imprex/orebfuscator/nms/AbstractBlockState.java
+++ b/orebfuscator-nms/orebfuscator-nms-api/src/main/java/net/imprex/orebfuscator/nms/AbstractBlockState.java
@@ -4,36 +4,46 @@ import org.bukkit.World;
 
 import net.imprex.orebfuscator.util.BlockPos;
 
-public abstract class AbstractBlockState<T> extends BlockPos implements BlockStateHolder {
+public abstract class AbstractBlockState<T> implements BlockStateHolder {
 
-	public final World world;
+	protected final World world;
+	private final BlockPos position;
 
 	protected final T state;
 
 	public AbstractBlockState(int x, int y, int z, World world, T state) {
-		super(x, y, z);
-
 		this.world = world;
+		this.position = new BlockPos(x, y, z);
 		this.state = state;
 	}
 
 	@Override
+	public World getWorld() {
+		return this.world;
+	}
+
+	@Override
+	public BlockPos getPosition() {
+		return position;
+	}
+
+	@Override
 	public int getX() {
-		return this.x;
+		return this.position.x;
 	}
 
 	@Override
 	public int getY() {
-		return this.y;
+		return this.position.y;
 	}
 
 	@Override
 	public int getZ() {
-		return this.z;
+		return this.position.z;
 	}
 
 	@Override
 	public String toString() {
-		return "[" + this.x + ", " + this.y + ", " + this.z + ", " + this.state + "]";
+		return "[" + this.world + ", " + this.position + ", " + this.state + "]";
 	}
 }

--- a/orebfuscator-nms/orebfuscator-nms-api/src/main/java/net/imprex/orebfuscator/nms/BlockStateHolder.java
+++ b/orebfuscator-nms/orebfuscator-nms-api/src/main/java/net/imprex/orebfuscator/nms/BlockStateHolder.java
@@ -1,14 +1,18 @@
 package net.imprex.orebfuscator.nms;
 
+import org.bukkit.World;
+
+import net.imprex.orebfuscator.util.BlockPos;
+
 public interface BlockStateHolder {
 
+	World getWorld();
+	BlockPos getPosition();
+
 	int getX();
-
 	int getY();
-
 	int getZ();
 
 	int getBlockId();
-
 	void notifyBlockChange();
 }

--- a/orebfuscator-nms/orebfuscator-nms-v1_10_R1/src/main/java/net/imprex/orebfuscator/nms/v1_10_R1/BlockState.java
+++ b/orebfuscator-nms/orebfuscator-nms-v1_10_R1/src/main/java/net/imprex/orebfuscator/nms/v1_10_R1/BlockState.java
@@ -22,6 +22,6 @@ public class BlockState extends AbstractBlockState<IBlockData> {
 	@Override
 	public void notifyBlockChange() {
 		WorldServer worldServer = ((CraftWorld) this.world).getHandle();
-		worldServer.notify(new BlockPosition(this.x, this.y, this.z), this.state, this.state, 0);
+		worldServer.notify(new BlockPosition(this.getX(), this.getY(), this.getZ()), this.state, this.state, 0);
 	}
 }

--- a/orebfuscator-nms/orebfuscator-nms-v1_11_R1/src/main/java/net/imprex/orebfuscator/nms/v1_11_R1/BlockState.java
+++ b/orebfuscator-nms/orebfuscator-nms-v1_11_R1/src/main/java/net/imprex/orebfuscator/nms/v1_11_R1/BlockState.java
@@ -22,6 +22,6 @@ public class BlockState extends AbstractBlockState<IBlockData> {
 	@Override
 	public void notifyBlockChange() {
 		WorldServer worldServer = ((CraftWorld) this.world).getHandle();
-		worldServer.notify(new BlockPosition(this.x, this.y, this.z), this.state, this.state, 0);
+		worldServer.notify(new BlockPosition(this.getX(), this.getY(), this.getZ()), this.state, this.state, 0);
 	}
 }

--- a/orebfuscator-nms/orebfuscator-nms-v1_12_R1/src/main/java/net/imprex/orebfuscator/nms/v1_12_R1/BlockState.java
+++ b/orebfuscator-nms/orebfuscator-nms-v1_12_R1/src/main/java/net/imprex/orebfuscator/nms/v1_12_R1/BlockState.java
@@ -22,6 +22,6 @@ public class BlockState extends AbstractBlockState<IBlockData> {
 	@Override
 	public void notifyBlockChange() {
 		WorldServer worldServer = ((CraftWorld) this.world).getHandle();
-		worldServer.notify(new BlockPosition(this.x, this.y, this.z), this.state, this.state, 0);
+		worldServer.notify(new BlockPosition(this.getX(), this.getY(), this.getZ()), this.state, this.state, 0);
 	}
 }

--- a/orebfuscator-nms/orebfuscator-nms-v1_13_R1/src/main/java/net/imprex/orebfuscator/nms/v1_13_R1/BlockState.java
+++ b/orebfuscator-nms/orebfuscator-nms-v1_13_R1/src/main/java/net/imprex/orebfuscator/nms/v1_13_R1/BlockState.java
@@ -22,6 +22,6 @@ public class BlockState extends AbstractBlockState<IBlockData> {
 	@Override
 	public void notifyBlockChange() {
 		WorldServer worldServer = ((CraftWorld) this.world).getHandle();
-		worldServer.notify(new BlockPosition(this.x, this.y, this.z), this.state, this.state, 0);
+		worldServer.notify(new BlockPosition(this.getX(), this.getY(), this.getZ()), this.state, this.state, 0);
 	}
 }

--- a/orebfuscator-nms/orebfuscator-nms-v1_13_R2/src/main/java/net/imprex/orebfuscator/nms/v1_13_R2/BlockState.java
+++ b/orebfuscator-nms/orebfuscator-nms-v1_13_R2/src/main/java/net/imprex/orebfuscator/nms/v1_13_R2/BlockState.java
@@ -22,6 +22,6 @@ public class BlockState extends AbstractBlockState<IBlockData> {
 	@Override
 	public void notifyBlockChange() {
 		WorldServer worldServer = ((CraftWorld) this.world).getHandle();
-		worldServer.notify(new BlockPosition(this.x, this.y, this.z), this.state, this.state, 0);
+		worldServer.notify(new BlockPosition(this.getX(), this.getY(), this.getZ()), this.state, this.state, 0);
 	}
 }

--- a/orebfuscator-nms/orebfuscator-nms-v1_14_R1/src/main/java/net/imprex/orebfuscator/nms/v1_14_R1/BlockState.java
+++ b/orebfuscator-nms/orebfuscator-nms-v1_14_R1/src/main/java/net/imprex/orebfuscator/nms/v1_14_R1/BlockState.java
@@ -22,6 +22,6 @@ public class BlockState extends AbstractBlockState<IBlockData> {
 	@Override
 	public void notifyBlockChange() {
 		WorldServer worldServer = ((CraftWorld) this.world).getHandle();
-		worldServer.getChunkProvider().flagDirty(new BlockPosition(this.x, this.y, this.z));
+		worldServer.getChunkProvider().flagDirty(new BlockPosition(this.getX(), this.getY(), this.getZ()));
 	}
 }

--- a/orebfuscator-nms/orebfuscator-nms-v1_15_R1/src/main/java/net/imprex/orebfuscator/nms/v1_15_R1/BlockState.java
+++ b/orebfuscator-nms/orebfuscator-nms-v1_15_R1/src/main/java/net/imprex/orebfuscator/nms/v1_15_R1/BlockState.java
@@ -22,6 +22,6 @@ public class BlockState extends AbstractBlockState<IBlockData> {
 	@Override
 	public void notifyBlockChange() {
 		WorldServer worldServer = ((CraftWorld) this.world).getHandle();
-		worldServer.getChunkProvider().flagDirty(new BlockPosition(this.x, this.y, this.z));
+		worldServer.getChunkProvider().flagDirty(new BlockPosition(this.getX(), this.getY(), this.getZ()));
 	}
 }

--- a/orebfuscator-nms/orebfuscator-nms-v1_16_R1/src/main/java/net/imprex/orebfuscator/nms/v1_16_R1/BlockState.java
+++ b/orebfuscator-nms/orebfuscator-nms-v1_16_R1/src/main/java/net/imprex/orebfuscator/nms/v1_16_R1/BlockState.java
@@ -22,6 +22,6 @@ public class BlockState extends AbstractBlockState<IBlockData> {
 	@Override
 	public void notifyBlockChange() {
 		WorldServer worldServer = ((CraftWorld) this.world).getHandle();
-		worldServer.getChunkProvider().flagDirty(new BlockPosition(this.x, this.y, this.z));
+		worldServer.getChunkProvider().flagDirty(new BlockPosition(this.getX(), this.getY(), this.getZ()));
 	}
 }

--- a/orebfuscator-nms/orebfuscator-nms-v1_16_R2/src/main/java/net/imprex/orebfuscator/nms/v1_16_R2/BlockState.java
+++ b/orebfuscator-nms/orebfuscator-nms-v1_16_R2/src/main/java/net/imprex/orebfuscator/nms/v1_16_R2/BlockState.java
@@ -22,6 +22,6 @@ public class BlockState extends AbstractBlockState<IBlockData> {
 	@Override
 	public void notifyBlockChange() {
 		WorldServer worldServer = ((CraftWorld) this.world).getHandle();
-		worldServer.getChunkProvider().flagDirty(new BlockPosition(this.x, this.y, this.z));
+		worldServer.getChunkProvider().flagDirty(new BlockPosition(this.getX(), this.getY(), this.getZ()));
 	}
 }

--- a/orebfuscator-nms/orebfuscator-nms-v1_16_R3/src/main/java/net/imprex/orebfuscator/nms/v1_16_R3/BlockState.java
+++ b/orebfuscator-nms/orebfuscator-nms-v1_16_R3/src/main/java/net/imprex/orebfuscator/nms/v1_16_R3/BlockState.java
@@ -22,6 +22,6 @@ public class BlockState extends AbstractBlockState<IBlockData> {
 	@Override
 	public void notifyBlockChange() {
 		WorldServer worldServer = ((CraftWorld) this.world).getHandle();
-		worldServer.getChunkProvider().flagDirty(new BlockPosition(this.x, this.y, this.z));
+		worldServer.getChunkProvider().flagDirty(new BlockPosition(this.getX(), this.getY(), this.getZ()));
 	}
 }

--- a/orebfuscator-nms/orebfuscator-nms-v1_9_R2/src/main/java/net/imprex/orebfuscator/nms/v1_9_R2/BlockState.java
+++ b/orebfuscator-nms/orebfuscator-nms-v1_9_R2/src/main/java/net/imprex/orebfuscator/nms/v1_9_R2/BlockState.java
@@ -22,6 +22,6 @@ public class BlockState extends AbstractBlockState<IBlockData> {
 	@Override
 	public void notifyBlockChange() {
 		WorldServer worldServer = ((CraftWorld) this.world).getHandle();
-		worldServer.notify(new BlockPosition(this.x, this.y, this.z), this.state, this.state, 0);
+		worldServer.notify(new BlockPosition(this.getX(), this.getY(), this.getZ()), this.state, this.state, 0);
 	}
 }

--- a/orebfuscator-plugin/pom.xml
+++ b/orebfuscator-plugin/pom.xml
@@ -50,6 +50,12 @@
 		</dependency>
 		<dependency>
 			<groupId>net.imprex</groupId>
+			<artifactId>orebfuscator-api</artifactId>
+			<version>${revision}</version>
+			<scope>compile</scope>
+		</dependency>
+		<dependency>
+			<groupId>net.imprex</groupId>
 			<artifactId>orebfuscator-common</artifactId>
 			<version>${revision}</version>
 			<scope>compile</scope>

--- a/orebfuscator-plugin/src/main/java/net/imprex/orebfuscator/DefaultOrebfuscatorService.java
+++ b/orebfuscator-plugin/src/main/java/net/imprex/orebfuscator/DefaultOrebfuscatorService.java
@@ -1,0 +1,40 @@
+package net.imprex.orebfuscator;
+
+import java.util.Collection;
+import java.util.Iterator;
+
+import org.bukkit.World;
+import org.bukkit.block.Block;
+
+import net.imprex.orebfuscator.api.OrebfuscatorService;
+import net.imprex.orebfuscator.obfuscation.ObfuscatorSystem;
+
+public final class DefaultOrebfuscatorService implements OrebfuscatorService {
+
+	private final Orebfuscator orebfuscator;
+	private final ObfuscatorSystem obfuscatorSystem;
+
+	public DefaultOrebfuscatorService(Orebfuscator orebfuscator) {
+		this.orebfuscator = orebfuscator;
+		this.obfuscatorSystem = orebfuscator.getObfuscatorSystem();
+	}
+
+	@Override
+	public final void deobfuscate(Collection<? extends Block> blocks) {
+		if (!this.orebfuscator.isMainThread()) {
+            throw new IllegalStateException("Asynchronous deobfuscation!");
+		} else if (blocks == null || blocks.isEmpty()) {
+			throw new IllegalArgumentException("block list is null or empty");
+		}
+
+		Iterator<? extends Block> blockIterator = blocks.iterator();
+		World world = blockIterator.next().getWorld();
+		while (blockIterator.hasNext()) {
+			if (blockIterator.next().getWorld() != world) {
+				throw new IllegalArgumentException("block list is located in more than one world");
+			}
+		}
+
+		this.obfuscatorSystem.deobfuscate(blocks);
+	}
+}

--- a/orebfuscator-plugin/src/main/java/net/imprex/orebfuscator/NmsInstance.java
+++ b/orebfuscator-plugin/src/main/java/net/imprex/orebfuscator/NmsInstance.java
@@ -6,6 +6,7 @@ import java.util.Set;
 
 import org.bukkit.Material;
 import org.bukkit.World;
+import org.bukkit.block.Block;
 import org.bukkit.entity.Player;
 
 import net.imprex.orebfuscator.config.Config;
@@ -76,6 +77,10 @@ public class NmsInstance {
 
 	public static boolean isTileEntity(int blockId) {
 		return instance.isTileEntity(blockId);
+	}
+
+	public static BlockStateHolder getBlockState(World world, Block block) {
+		return instance.getBlockState(world, block.getX(), block.getY(), block.getZ());
 	}
 
 	public static BlockStateHolder getBlockState(World world, int x, int y, int z) {

--- a/orebfuscator-plugin/src/main/java/net/imprex/orebfuscator/Orebfuscator.java
+++ b/orebfuscator-plugin/src/main/java/net/imprex/orebfuscator/Orebfuscator.java
@@ -8,8 +8,10 @@ import org.bukkit.event.EventPriority;
 import org.bukkit.event.HandlerList;
 import org.bukkit.event.Listener;
 import org.bukkit.event.server.PluginEnableEvent;
+import org.bukkit.plugin.ServicePriority;
 import org.bukkit.plugin.java.JavaPlugin;
 
+import net.imprex.orebfuscator.api.OrebfuscatorService;
 import net.imprex.orebfuscator.cache.ChunkCache;
 import net.imprex.orebfuscator.config.OrebfuscatorConfig;
 import net.imprex.orebfuscator.obfuscation.ObfuscatorSystem;
@@ -70,6 +72,12 @@ public class Orebfuscator extends JavaPlugin implements Listener {
 
 			// Store formatted config
 			this.config.store();
+			
+			// initialize service
+			Bukkit.getServicesManager().register(
+					OrebfuscatorService.class,
+					new DefaultOrebfuscatorService(this),
+					this, ServicePriority.Normal);
 		} catch (Exception e) {
 			OFCLogger.log(Level.SEVERE, "An error occurred while enabling plugin");
 			OFCLogger.err(e);

--- a/orebfuscator-plugin/src/main/java/net/imprex/orebfuscator/config/OrebfuscatorProximityConfig.java
+++ b/orebfuscator-plugin/src/main/java/net/imprex/orebfuscator/config/OrebfuscatorProximityConfig.java
@@ -82,7 +82,7 @@ public class OrebfuscatorProximityConfig implements ProximityConfig {
 
 		section.set("defaults.y", HideCondition.getY(this.defaultBlockFlags));
 		section.set("defaults.above", HideCondition.getAbove(this.defaultBlockFlags));
-		section.set("defaults.useBlockBelow", BlockMask.isUseBlockBelowSet(this.defaultBlockFlags));
+		section.set("defaults.useBlockBelow", BlockMask.isUseBlockBelowBitSet(this.defaultBlockFlags));
 
 		this.deserializeHiddenBlocks(section, this.hiddenBlocks, "hiddenBlocks");
 		ConfigParser.deserializeRandomMaterialList(section, randomBlocks, "randomBlocks");
@@ -141,8 +141,8 @@ public class OrebfuscatorProximityConfig implements ProximityConfig {
 				childSection.set("above", HideCondition.getAbove(blockFlags));
 			}
 
-			if (BlockMask.isUseBlockBelowSet(blockFlags) != BlockMask.isUseBlockBelowSet(this.defaultBlockFlags)) {
-				childSection.set("useBlockBelow", BlockMask.isUseBlockBelowSet(blockFlags));
+			if (BlockMask.isUseBlockBelowBitSet(blockFlags) != BlockMask.isUseBlockBelowBitSet(this.defaultBlockFlags)) {
+				childSection.set("useBlockBelow", BlockMask.isUseBlockBelowBitSet(blockFlags));
 			}
 		}
 	}

--- a/orebfuscator-plugin/src/main/java/net/imprex/orebfuscator/obfuscation/DeobfuscationListener.java
+++ b/orebfuscator-plugin/src/main/java/net/imprex/orebfuscator/obfuscation/DeobfuscationListener.java
@@ -54,22 +54,22 @@ public class DeobfuscationListener implements Listener {
 
 	@EventHandler
 	public void onBlockExplode(BlockExplodeEvent event) {
-		this.deobfuscator.deobfuscate(event.blockList());
+		this.deobfuscator.deobfuscate(event.blockList(), true);
 	}
 
 	@EventHandler
 	public void onBlockPistonExtend(BlockPistonExtendEvent event) {
-		this.deobfuscator.deobfuscate(event.getBlocks());
+		this.deobfuscator.deobfuscate(event.getBlocks(), true);
 	}
 
 	@EventHandler
 	public void onBlockPistonRetract(BlockPistonRetractEvent event) {
-		this.deobfuscator.deobfuscate(event.getBlocks());
+		this.deobfuscator.deobfuscate(event.getBlocks(), true);
 	}
 
 	@EventHandler
 	public void onEntityExplode(EntityExplodeEvent event) {
-		this.deobfuscator.deobfuscate(event.blockList());
+		this.deobfuscator.deobfuscate(event.blockList(), true);
 	}
 
 	@EventHandler

--- a/orebfuscator-plugin/src/main/java/net/imprex/orebfuscator/obfuscation/DeobfuscationListener.java
+++ b/orebfuscator-plugin/src/main/java/net/imprex/orebfuscator/obfuscation/DeobfuscationListener.java
@@ -1,12 +1,5 @@
 package net.imprex.orebfuscator.obfuscation;
 
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-
-import org.bukkit.World;
-import org.bukkit.block.Block;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Event.Result;
 import org.bukkit.event.EventHandler;
@@ -27,146 +20,66 @@ import org.bukkit.event.player.PlayerJoinEvent;
 import net.imprex.orebfuscator.NmsInstance;
 import net.imprex.orebfuscator.Orebfuscator;
 import net.imprex.orebfuscator.UpdateSystem;
-import net.imprex.orebfuscator.cache.ChunkCache;
-import net.imprex.orebfuscator.config.BlockMask;
 import net.imprex.orebfuscator.config.OrebfuscatorConfig;
-import net.imprex.orebfuscator.config.WorldConfig;
-import net.imprex.orebfuscator.nms.BlockStateHolder;
-import net.imprex.orebfuscator.util.ChunkPosition;
 import net.imprex.orebfuscator.util.PermissionUtil;
 
 public class DeobfuscationListener implements Listener {
 
 	private final UpdateSystem updateSystem;
 	private final OrebfuscatorConfig config;
-	private final ChunkCache chunkCache;
+	private final Deobfuscator deobfuscator;
 
-	public DeobfuscationListener(Orebfuscator orebfuscator) {
+	public DeobfuscationListener(Orebfuscator orebfuscator, Deobfuscator deobfuscator) {
 		this.updateSystem = orebfuscator.getUpdateSystem();
 		this.config = orebfuscator.getOrebfuscatorConfig();
-		this.chunkCache = orebfuscator.getChunkCache();
-	}
-
-	private void onUpdate(Block block) {
-		if (block == null || !block.getType().isOccluding()) {
-			return;
-		}
-
-		onUpdate(Arrays.asList(block));
-	}
-
-	private void onUpdate(List<Block> blocks) {
-		if (blocks.isEmpty()) {
-			return;
-		}
-
-		World world = blocks.get(0).getWorld();
-		WorldConfig worldConfig = this.config.world(world);
-		if (worldConfig == null || !worldConfig.enabled()) {
-			return;
-		}
-
-		BlockMask blockMask = this.config.blockMask(world);
-
-		Set<BlockStateHolder> updateBlocks = new HashSet<>();
-		Set<ChunkPosition> invalidChunks = new HashSet<>();
-		int updateRadius = this.config.general().updateRadius();
-
-		for (Block block : blocks) {
-			if (block.getType().isOccluding()) {
-				int x = block.getX();
-				int y = block.getY();
-				int z = block.getZ();
-
-				BlockStateHolder blockState = NmsInstance.getBlockState(world, x, y, z);
-				if (blockState != null) {
-					getAdjacentBlocks(updateBlocks, world, blockMask, blockState, updateRadius);
-				}
-			}
-		}
-
-		for (BlockStateHolder blockState : updateBlocks) {
-			blockState.notifyBlockChange();
-			invalidChunks.add(new ChunkPosition(world, blockState.getX() >> 4, blockState.getZ() >> 4));
-		}
-
-		if (!invalidChunks.isEmpty() && config.cache().enabled()) {
-			for (ChunkPosition chunk : invalidChunks) {
-				chunkCache.invalidate(chunk);
-			}
-		}
-	}
-
-	private void getAdjacentBlocks(Set<BlockStateHolder> updateBlocks, World world, BlockMask blockMask,
-			BlockStateHolder blockState, int depth) {
-		if (blockState == null) {
-			return;
-		}
-
-		int blockId = blockState.getBlockId();
-		if (BlockMask.isObfuscateSet(blockMask.mask(blockId))) {
-			updateBlocks.add(blockState);
-		}
-
-		if (depth-- > 0) {
-			int x = blockState.getX();
-			int y = blockState.getY();
-			int z = blockState.getZ();
-
-			getAdjacentBlocks(updateBlocks, world, blockMask, NmsInstance.getBlockState(world, x + 1, y, z), depth);
-			getAdjacentBlocks(updateBlocks, world, blockMask, NmsInstance.getBlockState(world, x - 1, y, z), depth);
-			getAdjacentBlocks(updateBlocks, world, blockMask, NmsInstance.getBlockState(world, x, y + 1, z), depth);
-			getAdjacentBlocks(updateBlocks, world, blockMask, NmsInstance.getBlockState(world, x, y - 1, z), depth);
-			getAdjacentBlocks(updateBlocks, world, blockMask, NmsInstance.getBlockState(world, x, y, z + 1), depth);
-			getAdjacentBlocks(updateBlocks, world, blockMask, NmsInstance.getBlockState(world, x, y, z - 1), depth);
-		}
+		this.deobfuscator = deobfuscator;
 	}
 
 	@EventHandler
 	public void onBlockDamage(BlockDamageEvent event) {
 		if (this.config.general().updateOnBlockDamage()) {
-			this.onUpdate(event.getBlock());
+			this.deobfuscator.deobfuscate(event.getBlock());
 		}
 	}
 
 	@EventHandler
 	public void onBlockBreak(BlockBreakEvent event) {
-		this.onUpdate(event.getBlock());
+		this.deobfuscator.deobfuscate(event.getBlock());
 	}
 
 	@EventHandler
 	public void onBlockBurn(BlockBurnEvent event) {
-		this.onUpdate(event.getBlock());
+		this.deobfuscator.deobfuscate(event.getBlock());
 	}
 
 	@EventHandler
 	public void onBlockExplode(BlockExplodeEvent event) {
-		this.onUpdate(event.blockList());
+		this.deobfuscator.deobfuscate(event.blockList());
 	}
 
 	@EventHandler
 	public void onBlockPistonExtend(BlockPistonExtendEvent event) {
-		this.onUpdate(event.getBlocks());
+		this.deobfuscator.deobfuscate(event.getBlocks());
 	}
 
 	@EventHandler
 	public void onBlockPistonRetract(BlockPistonRetractEvent event) {
-		this.onUpdate(event.getBlocks());
+		this.deobfuscator.deobfuscate(event.getBlocks());
 	}
 
 	@EventHandler
 	public void onEntityExplode(EntityExplodeEvent event) {
-		this.onUpdate(event.blockList());
+		this.deobfuscator.deobfuscate(event.blockList());
 	}
 
 	@EventHandler
 	public void onEntityInteract(EntityInteractEvent event) {
-		this.onUpdate(event.getBlock());
+		this.deobfuscator.deobfuscate(event.getBlock());
 	}
 
 	@EventHandler
 	public void onEntityChangeBlock(EntityChangeBlockEvent event) {
-		this.onUpdate(event.getBlock());
+		this.deobfuscator.deobfuscate(event.getBlock());
 	}
 
 	@EventHandler
@@ -174,7 +87,7 @@ public class DeobfuscationListener implements Listener {
 		if (event.getAction() == Action.RIGHT_CLICK_BLOCK && event.useInteractedBlock() != Result.DENY
 				&& event.getItem() != null && event.getItem().getType() != null
 				&& NmsInstance.isHoe(event.getItem().getType())) {
-			this.onUpdate(event.getClickedBlock());
+			this.deobfuscator.deobfuscate(event.getClickedBlock());
 		}
 	}
 

--- a/orebfuscator-plugin/src/main/java/net/imprex/orebfuscator/obfuscation/Deobfuscator.java
+++ b/orebfuscator-plugin/src/main/java/net/imprex/orebfuscator/obfuscation/Deobfuscator.java
@@ -1,0 +1,106 @@
+package net.imprex.orebfuscator.obfuscation;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.bukkit.World;
+import org.bukkit.block.Block;
+
+import com.google.common.collect.Iterables;
+
+import net.imprex.orebfuscator.NmsInstance;
+import net.imprex.orebfuscator.Orebfuscator;
+import net.imprex.orebfuscator.cache.ChunkCache;
+import net.imprex.orebfuscator.config.BlockMask;
+import net.imprex.orebfuscator.config.OrebfuscatorConfig;
+import net.imprex.orebfuscator.config.WorldConfig;
+import net.imprex.orebfuscator.nms.BlockStateHolder;
+import net.imprex.orebfuscator.util.ChunkPosition;
+
+public class Deobfuscator {
+
+	private final OrebfuscatorConfig config;
+	private final ChunkCache chunkCache;
+
+	public Deobfuscator(Orebfuscator orebfuscator) {
+		this.config = orebfuscator.getOrebfuscatorConfig();
+		this.chunkCache = orebfuscator.getChunkCache();
+	}
+
+	void deobfuscate(Block block) {
+		if (block == null || !block.getType().isOccluding()) {
+			return;
+		}
+
+		deobfuscate(Arrays.asList(block));
+	}
+
+	public void deobfuscate(Collection<? extends Block> blocks) {
+		if (blocks.isEmpty()) {
+			return;
+		}
+
+		World world = Iterables.get(blocks, 0).getWorld();
+		WorldConfig worldConfig = this.config.world(world);
+		if (worldConfig == null || !worldConfig.enabled()) {
+			return;
+		}
+
+		BlockMask blockMask = this.config.blockMask(world);
+
+		Set<BlockStateHolder> updateBlocks = new HashSet<>();
+		Set<ChunkPosition> invalidChunks = new HashSet<>();
+		int updateRadius = this.config.general().updateRadius();
+
+		for (Block block : blocks) {
+			if (block.getType().isOccluding()) {
+				int x = block.getX();
+				int y = block.getY();
+				int z = block.getZ();
+
+				BlockStateHolder blockState = NmsInstance.getBlockState(world, x, y, z);
+				if (blockState != null) {
+					getAdjacentBlocks(updateBlocks, world, blockMask, blockState, updateRadius);
+				}
+			}
+		}
+
+		for (BlockStateHolder blockState : updateBlocks) {
+			blockState.notifyBlockChange();
+			invalidChunks.add(new ChunkPosition(world, blockState.getX() >> 4, blockState.getZ() >> 4));
+		}
+
+		if (!invalidChunks.isEmpty() && config.cache().enabled()) {
+			for (ChunkPosition chunk : invalidChunks) {
+				chunkCache.invalidate(chunk);
+			}
+		}
+	}
+
+	private void getAdjacentBlocks(Set<BlockStateHolder> updateBlocks, World world, BlockMask blockMask,
+			BlockStateHolder blockState, int depth) {
+		if (blockState == null) {
+			return;
+		}
+
+		int blockId = blockState.getBlockId();
+		if (BlockMask.isObfuscateSet(blockMask.mask(blockId))) {
+			updateBlocks.add(blockState);
+		}
+
+		if (depth-- > 0) {
+			int x = blockState.getX();
+			int y = blockState.getY();
+			int z = blockState.getZ();
+
+			getAdjacentBlocks(updateBlocks, world, blockMask, NmsInstance.getBlockState(world, x + 1, y, z), depth);
+			getAdjacentBlocks(updateBlocks, world, blockMask, NmsInstance.getBlockState(world, x - 1, y, z), depth);
+			getAdjacentBlocks(updateBlocks, world, blockMask, NmsInstance.getBlockState(world, x, y + 1, z), depth);
+			getAdjacentBlocks(updateBlocks, world, blockMask, NmsInstance.getBlockState(world, x, y - 1, z), depth);
+			getAdjacentBlocks(updateBlocks, world, blockMask, NmsInstance.getBlockState(world, x, y, z + 1), depth);
+			getAdjacentBlocks(updateBlocks, world, blockMask, NmsInstance.getBlockState(world, x, y, z - 1), depth);
+		}
+	}
+}

--- a/orebfuscator-plugin/src/main/java/net/imprex/orebfuscator/obfuscation/Obfuscator.java
+++ b/orebfuscator-plugin/src/main/java/net/imprex/orebfuscator/obfuscation/Obfuscator.java
@@ -82,17 +82,17 @@ public class Obfuscator {
 					boolean obfuscated = false;
 
 					// should current block be obfuscated
-					if (BlockMask.isObfuscateSet(obfuscateBits)
+					if (BlockMask.isObfuscateBitSet(obfuscateBits)
 							&& shouldObfuscate(chunk, world, x, y, z, initialRadius)) {
 						blockData = worldConfig.randomBlockId();
 						obfuscated = true;
 					}
 
 					// should current block be proximity hidden
-					if (!obfuscated && BlockMask.isProximitySet(obfuscateBits)) {
+					if (!obfuscated && BlockMask.isProximityBitSet(obfuscateBits)) {
 						proximityBlocks.add(new BlockPos(x, y, z));
 						obfuscated = true;
-						if (BlockMask.isUseBlockBelowSet(obfuscateBits)) {
+						if (BlockMask.isUseBlockBelowBitSet(obfuscateBits)) {
 							blockData = getBlockBelow(blockMask, chunk, x, y, z);
 						} else {
 							blockData = proximityConfig.randomBlockId();
@@ -102,7 +102,7 @@ public class Obfuscator {
 					// update block state if needed
 					if (obfuscated) {
 						chunkSection.setBlock(index, blockData);
-						if (BlockMask.isTileEntitySet(obfuscateBits)) {
+						if (BlockMask.isTileEntityBitSet(obfuscateBits)) {
 							removedTileEntities.add(new BlockPos(x, y, z));
 						}
 					}

--- a/orebfuscator-plugin/src/main/java/net/imprex/orebfuscator/obfuscation/ObfuscatorSystem.java
+++ b/orebfuscator-plugin/src/main/java/net/imprex/orebfuscator/obfuscation/ObfuscatorSystem.java
@@ -54,7 +54,7 @@ public class ObfuscatorSystem {
 	}
 
 	public void deobfuscate(Collection<? extends Block> blocks) {
-		this.deobfuscator.deobfuscate(blocks);
+		this.deobfuscator.deobfuscate(blocks, false);
 	}
 
 	public void close() {

--- a/orebfuscator-plugin/src/main/java/net/imprex/orebfuscator/obfuscation/ObfuscatorSystem.java
+++ b/orebfuscator-plugin/src/main/java/net/imprex/orebfuscator/obfuscation/ObfuscatorSystem.java
@@ -1,8 +1,10 @@
 package net.imprex.orebfuscator.obfuscation;
 
+import java.util.Collection;
 import java.util.concurrent.CompletableFuture;
 
 import org.bukkit.Bukkit;
+import org.bukkit.block.Block;
 
 import net.imprex.orebfuscator.Orebfuscator;
 import net.imprex.orebfuscator.cache.ChunkCache;
@@ -18,6 +20,7 @@ public class ObfuscatorSystem {
 	private final ChunkCache chunkCache;
 
 	private final Obfuscator obfuscator;
+	private final Deobfuscator deobfuscator;
 	private AbstractChunkListener chunkListener;
 
 	public ObfuscatorSystem(Orebfuscator orebfuscator) {
@@ -26,7 +29,8 @@ public class ObfuscatorSystem {
 		this.chunkCache = orebfuscator.getChunkCache();
 
 		this.obfuscator = new Obfuscator(orebfuscator);
-		Bukkit.getPluginManager().registerEvents(new DeobfuscationListener(orebfuscator), orebfuscator);
+		this.deobfuscator = new Deobfuscator(orebfuscator);
+		Bukkit.getPluginManager().registerEvents(new DeobfuscationListener(orebfuscator, this.deobfuscator), orebfuscator);
 	}
 
 	public void registerChunkListener() {
@@ -47,6 +51,10 @@ public class ObfuscatorSystem {
 		} else {
 			return this.obfuscator.obfuscate(request);
 		}
+	}
+
+	public void deobfuscate(Collection<? extends Block> blocks) {
+		this.deobfuscator.deobfuscate(blocks);
 	}
 
 	public void close() {

--- a/pom.xml
+++ b/pom.xml
@@ -47,5 +47,7 @@
 		<module>orebfuscator-plugin</module>
 		<module>orebfuscator-nms</module>
 		<module>orebfuscator-common</module>
+		<module>orebfuscator-api</module>
+		<module>orebfuscator-api-example</module>
 	</modules>
 </project>


### PR DESCRIPTION
Add a simple API for other plugins to use.

## Description
Add a simple API that enables other plugins to deobfuscate blocks. API may be extended in the future.

## Related Issue
closes #85
#82

## Motivation and Context
Prior versions had a simple API for deobfuscation.

## How Has This Been Tested?
Tested with latest spigot and api example project.

## Types of Changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
