### PR TITLE
Updated plugin.xml description to work on 1.17

### DIFF
--- a/orebfuscator-plugin/src/main/resources/plugin.yml
+++ b/orebfuscator-plugin/src/main/resources/plugin.yml
@@ -13,7 +13,7 @@ loadbefore: [ProtocolLib]
 
 load: POSTWORLD
 
-description: 'High-Performance Anti X-Ray'
+description: "High-Performance Anti X-Ray"
 
 permissions:
   orebfuscator.admin:


### PR DESCRIPTION
Edit: this might be a problem with my server host. If so, I apologize for the inconvenience.

## Description
Fixed bug that stops the plugin from loading in 1.17.


## Motivation and Context
The plugin does not load due to an error:

```
18.06 02:15:22 [Server] Server thread/ERROR Could not load 'plugins/orebfuscator-plugin-5.1.5.jar' in folder 'plugins'
18.06 02:15:22 [Server] INFO org.bukkit.plugin.InvalidDescriptionException: Invalid plugin.yml
```

## How Has This Been Tested?
I started the server and was immediately shown the error above.


## Types of Changes
Replaced ' with " in plugin.yml description.
