### PR TITLE
[#122] Fix HeightAccessor initialization error

### DIFF
--- a/orebfuscator-plugin/src/main/java/net/imprex/orebfuscator/Orebfuscator.java
+++ b/orebfuscator-plugin/src/main/java/net/imprex/orebfuscator/Orebfuscator.java
@@ -18,6 +18,7 @@ import net.imprex.orebfuscator.obfuscation.ObfuscatorSystem;
 import net.imprex.orebfuscator.proximityhider.ProximityHider;
 import net.imprex.orebfuscator.proximityhider.ProximityListener;
 import net.imprex.orebfuscator.proximityhider.ProximityPacketListener;
+import net.imprex.orebfuscator.util.HeightAccessor;
 import net.imprex.orebfuscator.util.OFCLogger;
 
 public class Orebfuscator extends JavaPlugin implements Listener {
@@ -41,6 +42,9 @@ public class Orebfuscator extends JavaPlugin implements Listener {
 				OFCLogger.info("ProtocolLib is not found! Plugin cannot be enabled.");
 				return;
 			}
+
+			// Check if HeightAccessor can be loaded
+			HeightAccessor.ThisMethodIsUsedToInitializeStaticFields();
 
 			// Load configurations
 			this.config = new OrebfuscatorConfig(this);

--- a/orebfuscator-plugin/src/main/java/net/imprex/orebfuscator/util/HeightAccessor.java
+++ b/orebfuscator-plugin/src/main/java/net/imprex/orebfuscator/util/HeightAccessor.java
@@ -23,9 +23,28 @@ public class HeightAccessor {
 
 	private static MethodAccessor getWorldMethod(String methodName) {
 		if (ChunkCapabilities.hasDynamicHeight()) {
-			return Accessors.getMethodAccessor(World.class, methodName);
+			MethodAccessor methodAccessor = getWorldMethod0(methodName);
+			OFCLogger.info("HeightAccessor found method: World::" + methodName + "()");
+			return methodAccessor;
 		}
 		return null;
+	}
+
+	private static MethodAccessor getWorldMethod0(String methodName) {
+		try {
+			return Accessors.getMethodAccessor(World.class, methodName);
+		} catch (IllegalArgumentException e) {
+			for (Class<?> iterface : World.class.getInterfaces()) {
+				try {
+					return Accessors.getMethodAccessor(iterface, methodName);
+				} catch (IllegalArgumentException e2) {
+				}
+			}
+		}
+		throw new RuntimeException("unable to find method: World::" + methodName + "()");
+	}
+
+	public static void ThisMethodIsUsedToInitializeStaticFields() {
 	}
 
 	private final int maxHeight;


### PR DESCRIPTION
Fix the class initialization error of HeightAccessor.

## Description
The HeightAccessor's static constructor is now called onEnable. `HeightAccessor::getWorldMethod` now check all Interfaces of `World.class`.

## Related Issue
closes #122

## Motivation and Context
Plugin doesn't work.

## How Has This Been Tested?
Tested with latest Spigot release.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
