### PR TITLE
[#124] Housekeeping

### DIFF
--- a/orebfuscator-plugin/pom.xml
+++ b/orebfuscator-plugin/pom.xml
@@ -145,9 +145,6 @@
 			<resource>
 				<directory>src/main/resources</directory>
 				<filtering>true</filtering>
-				<includes>
-					<include>plugin.yml</include>
-				</includes>
 			</resource>
 		</resources>
 		<plugins>

--- a/orebfuscator-plugin/src/main/java/net/imprex/orebfuscator/MetricsSystem.java
+++ b/orebfuscator-plugin/src/main/java/net/imprex/orebfuscator/MetricsSystem.java
@@ -1,11 +1,9 @@
 package net.imprex.orebfuscator;
 
-import java.util.HashMap;
-import java.util.Map;
-
 import org.bstats.bukkit.Metrics;
 
 import net.imprex.orebfuscator.config.OrebfuscatorConfig;
+import net.imprex.orebfuscator.util.MathUtil;
 
 public class MetricsSystem {
 
@@ -18,22 +16,9 @@ public class MetricsSystem {
 	}
 
 	public void addMemoryChart() {
-		this.metrics.addCustomChart(new Metrics.DrilldownPie("system_memory", () -> {
-			final Map<String, Map<String, Integer>> result = new HashMap<>();
-			final Map<String, Integer> exact = new HashMap<>();
-
-			long memory = Runtime.getRuntime().maxMemory();
-			if (memory == Long.MAX_VALUE) {
-				exact.put("unbound", 1);
-				result.put("unbound", exact);
-			} else {
-				long megaByte = (long) Math.ceil(memory / 1048576d);
-				long gigaByte = (long) Math.ceil(memory / 1073741824d);
-				exact.put(megaByte + "MiB", 1);
-				result.put(gigaByte + "GiB", exact);
-			}
-
-			return result;
+		this.metrics.addCustomChart(new Metrics.SimplePie("systemMemory", () -> {
+			int memory = (int) (Runtime.getRuntime().maxMemory() / 1073741824L);
+			return MathUtil.ceilToPowerOfTwo(memory) + "GiB";
 		}));
 	}
 

--- a/orebfuscator-plugin/src/main/java/net/imprex/orebfuscator/MetricsSystem.java
+++ b/orebfuscator-plugin/src/main/java/net/imprex/orebfuscator/MetricsSystem.java
@@ -1,5 +1,8 @@
 package net.imprex.orebfuscator;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import org.bstats.bukkit.Metrics;
 
 import net.imprex.orebfuscator.config.OrebfuscatorConfig;
@@ -16,9 +19,20 @@ public class MetricsSystem {
 	}
 
 	public void addMemoryChart() {
-		this.metrics.addCustomChart(new Metrics.SimplePie("systemMemory", () -> {
-			int memory = (int) (Runtime.getRuntime().maxMemory() / 1073741824L);
-			return MathUtil.ceilToPowerOfTwo(memory) + "GiB";
+		this.metrics.addCustomChart(new Metrics.DrilldownPie("systemMemory", () -> {
+			final Map<String, Map<String, Integer>> result = new HashMap<>();
+			final Map<String, Integer> exact = new HashMap<>();
+
+			long memory = Runtime.getRuntime().maxMemory();
+			if (memory == Long.MAX_VALUE) {
+				result.put("unlimited", exact);
+			} else {
+				int gibiByte = (int) (memory / 1073741824L);
+				exact.put(gibiByte + "GiB", 1);
+				result.put(MathUtil.ceilToPowerOfTwo(gibiByte) + "GiB", exact);
+			}
+
+			return result;
 		}));
 	}
 

--- a/orebfuscator-plugin/src/main/java/net/imprex/orebfuscator/util/MathUtil.java
+++ b/orebfuscator-plugin/src/main/java/net/imprex/orebfuscator/util/MathUtil.java
@@ -8,6 +8,17 @@ import net.imprex.orebfuscator.nms.BlockStateHolder;
 
 public class MathUtil {
 
+	public static int ceilToPowerOfTwo(int value) {
+		value--;
+		value |= value >> 1;
+		value |= value >> 2;
+		value |= value >> 4;
+		value |= value >> 8;
+		value |= value >> 16;
+		value++;
+		return value;
+	}
+
 	/**
 	 * Basic idea here is to take some rays from the considered block to the
 	 * player's eyes, and decide if any of those rays can reach the eyes unimpeded.

--- a/orebfuscator-plugin/src/main/resources/plugin.yml
+++ b/orebfuscator-plugin/src/main/resources/plugin.yml
@@ -2,6 +2,7 @@ api-version: 1.13
 
 name: Orebfuscator
 version: ${project.version}
+description: 'High-Performance Anti X-Ray'
 
 main: net.imprex.orebfuscator.Orebfuscator
 
@@ -9,15 +10,17 @@ author: Ingrim4
 authors: [NgLoader, lishid, SydMontague, ProgrammerDan, Aleksey-Terzi]
 
 depend: [ProtocolLib]
-loadbefore: [ProtocolLib]
-
-load: POSTWORLD
-
-description: 'High-Performance Anti X-Ray'
 
 permissions:
-  orebfuscator.admin:
-    default: true
-  orebfuscator.bypass:
-    description: Bypass obfuscation
+  orebfuscator.*:
     default: false
+    description: Access to all of Orebfuscator's features
+    children:
+      orebfuscator.admin: true
+      orebfuscator.bypass: true
+  orebfuscator.admin:
+    default: op
+    description: Access to update notifications
+  orebfuscator.bypass:
+    default: false
+    description: Bypass the obfuscation


### PR DESCRIPTION
Clean-up plugin.yml and change memory grouping for bstats.

## Description
- change `orebfuscator.admin` default from `true` to `op` in plugin.yml
- remove `ProtocolLib` from `loadbefore` in plugin.yml
- remove `load: POSTWORLD` from plugin.yml
- add `orebfuscator.*` permission to plugin.yml
- tidy up bstats memory metric

## Related Issue
closes #124 

## How Has This Been Tested?
Successfully tested with latest spigot build.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
