### PR TITLE
[#131] Catch TemporaryPlayer not implementing Player::hasPermission

### DIFF
--- a/orebfuscator-plugin/src/main/java/net/imprex/orebfuscator/util/PermissionUtil.java
+++ b/orebfuscator-plugin/src/main/java/net/imprex/orebfuscator/util/PermissionUtil.java
@@ -5,7 +5,12 @@ import org.bukkit.entity.Player;
 public class PermissionUtil {
 
 	public static boolean canDeobfuscate(Player player) {
-		return player.hasPermission("orebfuscator.bypass");
+		try {
+			return player.hasPermission("orebfuscator.bypass");
+		} catch (UnsupportedOperationException e) {
+			// fix #131: catch TemporaryPlayer not implementing hasPermission
+			return false;
+		}
 	}
 
 	public static boolean canCheckForUpdates(Player player) {


### PR DESCRIPTION


## Description
Fix ProtocolLib's TemporaryPlayer not implementing hasPermission. The throw exception will now be catched and return false for permission requests.

## Related Issue
closes #131 

## Motivation and Context

## How Has This Been Tested?
tested with latest spigot build

## Types of Changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
