### PR TITLE
[#164] Fix yaml config format

### DIFF
--- a/.github/workflows/buildtools.sh
+++ b/.github/workflows/buildtools.sh
@@ -34,5 +34,5 @@ if [ $1 = "java-8" ]; then
 elif [ $1 = "java-16" ]; then
 	checkVersion 1.17.1
 elif [ $1 = "java-17" ]; then
-	checkVersion 1.18
+	checkVersion 1.18.1
 fi

--- a/orebfuscator-nms/orebfuscator-nms-v1_17_R1/pom.xml
+++ b/orebfuscator-nms/orebfuscator-nms-v1_17_R1/pom.xml
@@ -42,9 +42,9 @@
 						</goals>
 						<id>remap-obf</id>
 						<configuration>
-							<srgIn>org.spigotmc:minecraft-server:1.17-R0.1-SNAPSHOT:txt:maps-mojang</srgIn>
+							<srgIn>org.spigotmc:minecraft-server:1.17.1-R0.1-SNAPSHOT:txt:maps-mojang</srgIn>
 							<reverse>true</reverse>
-							<remappedDependencies>org.spigotmc:spigot:1.17-R0.1-SNAPSHOT:jar:remapped-mojang</remappedDependencies>
+							<remappedDependencies>org.spigotmc:spigot:1.17.1-R0.1-SNAPSHOT:jar:remapped-mojang</remappedDependencies>
 							<remappedArtifactAttached>true</remappedArtifactAttached>
 							<remappedClassifierName>remapped-obf</remappedClassifierName>
 						</configuration>
@@ -57,8 +57,8 @@
 						<id>remap-spigot</id>
 						<configuration>
 							<inputFile>${project.build.directory}/${project.artifactId}-${project.version}-remapped-obf.jar</inputFile>
-							<srgIn>org.spigotmc:minecraft-server:1.17-R0.1-SNAPSHOT:csrg:maps-spigot</srgIn>
-							<remappedDependencies>org.spigotmc:spigot:1.17-R0.1-SNAPSHOT:jar:remapped-obf</remappedDependencies>
+							<srgIn>org.spigotmc:minecraft-server:1.17.1-R0.1-SNAPSHOT:csrg:maps-spigot</srgIn>
+							<remappedDependencies>org.spigotmc:spigot:1.17.1-R0.1-SNAPSHOT:jar:remapped-obf</remappedDependencies>
 						</configuration>
 					</execution>
 				</executions>

--- a/orebfuscator-nms/orebfuscator-nms-v1_18_R1/pom.xml
+++ b/orebfuscator-nms/orebfuscator-nms-v1_18_R1/pom.xml
@@ -22,7 +22,7 @@
 		<dependency>
 		    <groupId>org.spigotmc</groupId>
 		    <artifactId>spigot</artifactId>
-		    <version>1.18-R0.1-SNAPSHOT</version>
+		    <version>1.18.1-R0.1-SNAPSHOT</version>
 		    <classifier>remapped-mojang</classifier>
 		    <scope>provided</scope>
 		</dependency>
@@ -48,9 +48,9 @@
 						</goals>
 						<id>remap-obf</id>
 						<configuration>
-							<srgIn>org.spigotmc:minecraft-server:1.18-R0.1-SNAPSHOT:txt:maps-mojang</srgIn>
+							<srgIn>org.spigotmc:minecraft-server:1.18.1-R0.1-SNAPSHOT:txt:maps-mojang</srgIn>
 							<reverse>true</reverse>
-							<remappedDependencies>org.spigotmc:spigot:1.18-R0.1-SNAPSHOT:jar:remapped-mojang</remappedDependencies>
+							<remappedDependencies>org.spigotmc:spigot:1.18.1-R0.1-SNAPSHOT:jar:remapped-mojang</remappedDependencies>
 							<remappedArtifactAttached>true</remappedArtifactAttached>
 							<remappedClassifierName>remapped-obf</remappedClassifierName>
 						</configuration>
@@ -63,8 +63,8 @@
 						<id>remap-spigot</id>
 						<configuration>
 							<inputFile>${project.build.directory}/${project.artifactId}-${project.version}-remapped-obf.jar</inputFile>
-							<srgIn>org.spigotmc:minecraft-server:1.18-R0.1-SNAPSHOT:csrg:maps-spigot</srgIn>
-							<remappedDependencies>org.spigotmc:spigot:1.18-R0.1-SNAPSHOT:jar:remapped-obf</remappedDependencies>
+							<srgIn>org.spigotmc:minecraft-server:1.18.1-R0.1-SNAPSHOT:csrg:maps-spigot</srgIn>
+							<remappedDependencies>org.spigotmc:spigot:1.18.1-R0.1-SNAPSHOT:jar:remapped-obf</remappedDependencies>
 						</configuration>
 					</execution>
 				</executions>

--- a/orebfuscator-plugin/src/main/java/net/imprex/orebfuscator/config/AbstractWorldConfig.java
+++ b/orebfuscator-plugin/src/main/java/net/imprex/orebfuscator/config/AbstractWorldConfig.java
@@ -16,12 +16,18 @@ import net.imprex.orebfuscator.util.WeightedRandom;
 
 public abstract class AbstractWorldConfig implements WorldConfig {
 
+	private final String name;
+
 	protected boolean enabled = false;
 
 	protected final List<WorldMatcher> worldMatchers = new ArrayList<>();
 
 	protected final Map<Material, Integer> randomBlocks = new LinkedHashMap<>();
 	protected final WeightedRandom<Integer> weightedBlockIds = new WeightedRandom<>();
+
+	public AbstractWorldConfig(String name) {
+		this.name = name;
+	}
 
 	protected static void warnUnkownBlock(String section, String path, String name) {
 		OFCLogger.warn(String.format("config section '%s.%s' contains unknown block '%s'", section, path, name));
@@ -84,6 +90,10 @@ public abstract class AbstractWorldConfig implements WorldConfig {
 				warnUnkownBlock(section.getCurrentPath(), path, material.name());
 			}
 		}
+	}
+
+	public String getName() {
+		return name;
 	}
 
 	@Override

--- a/orebfuscator-plugin/src/main/java/net/imprex/orebfuscator/config/ConfigParser.java
+++ b/orebfuscator-plugin/src/main/java/net/imprex/orebfuscator/config/ConfigParser.java
@@ -8,7 +8,15 @@ import org.bukkit.configuration.ConfigurationSection;
 
 public class ConfigParser {
 
-	public static List<ConfigurationSection> deserializeSectionList(ConfigurationSection parentSection, String path) {
+	public static void convertSectionListToSection(ConfigurationSection parentSection, String path) {
+		List<ConfigurationSection> sections = deserializeSectionList(parentSection, path);
+		ConfigurationSection section = parentSection.createSection(path);
+		for (ConfigurationSection childSection : sections) {
+			section.set(childSection.getName(), childSection);
+		}
+	}
+
+	private static List<ConfigurationSection> deserializeSectionList(ConfigurationSection parentSection, String path) {
 		List<ConfigurationSection> sections = new ArrayList<>();
 
 		List<?> sectionList = parentSection.getList(path);

--- a/orebfuscator-plugin/src/main/java/net/imprex/orebfuscator/config/OrebfuscatorObfuscationConfig.java
+++ b/orebfuscator-plugin/src/main/java/net/imprex/orebfuscator/config/OrebfuscatorObfuscationConfig.java
@@ -16,6 +16,7 @@ public class OrebfuscatorObfuscationConfig extends AbstractWorldConfig implement
 	private final Set<Material> hiddenBlocks = new LinkedHashSet<>();
 
 	OrebfuscatorObfuscationConfig(ConfigurationSection section) {
+		super(section.getName());
 		this.enabled = section.getBoolean("enabled", true);
 		this.deserializeWorlds(section, "worlds");
 		this.deserializeHiddenBlocks(section, "hiddenBlocks");

--- a/orebfuscator-plugin/src/main/java/net/imprex/orebfuscator/config/OrebfuscatorProximityConfig.java
+++ b/orebfuscator-plugin/src/main/java/net/imprex/orebfuscator/config/OrebfuscatorProximityConfig.java
@@ -19,6 +19,7 @@ public class OrebfuscatorProximityConfig extends AbstractWorldConfig implements 
 	private Map<Material, Integer> hiddenBlocks = new LinkedHashMap<>();
 
 	OrebfuscatorProximityConfig(ConfigurationSection section) {
+		super(section.getName());
 		this.enabled = section.getBoolean("enabled", true);
 		this.deserializeWorlds(section, "worlds");
 


### PR DESCRIPTION
Convert all config section lists to a single section.

## Related Issue
closes #164

## Motivation and Context
Lists of config section can't be serialized anymore as of: [031731e60ec](https://hub.spigotmc.org/stash/projects/SPIGOT/repos/bukkit/commits/3e2dd2bc120754ea4db193e878050d0eb31a6894#src/main/java/org/bukkit/configuration/file/YamlConfiguration.java)

## How Has This Been Tested?
Tested with latest spigot build

## Types of Changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
