### PR TITLE
[#210] Remove heavy events

### DIFF
--- a/orebfuscator-nms/orebfuscator-nms-api/src/main/java/net/imprex/orebfuscator/nms/AbstractNmsManager.java
+++ b/orebfuscator-nms/orebfuscator-nms-api/src/main/java/net/imprex/orebfuscator/nms/AbstractNmsManager.java
@@ -15,8 +15,7 @@ public abstract class AbstractNmsManager implements NmsManager {
 
 	private static final byte FLAG_AIR = 1;
 	private static final byte FLAG_OCCLUDING = 2;
-	private static final byte FLAG_FALLABLE = 4;
-	private static final byte FLAG_TILE_ENTITY = 8;
+	private static final byte FLAG_TILE_ENTITY = 4;
 
 	private final AbstractRegionFileCache<?> regionFileCache;
 	private final Map<Material, Set<Integer>> materialToIds = new HashMap<>();
@@ -32,11 +31,10 @@ public abstract class AbstractNmsManager implements NmsManager {
 		this.materialToIds.computeIfAbsent(material, key -> new HashSet<>()).add(id);
 	}
 
-	protected final void setBlockFlags(int blockId, boolean isAir, boolean canOcclude, boolean canFall, boolean isTileEntity) {
+	protected final void setBlockFlags(int blockId, boolean isAir, boolean canOcclude, boolean isTileEntity) {
 		byte flags = this.blockFlags[blockId];
 		flags |= isAir ? FLAG_AIR : 0;
 		flags |= canOcclude ? FLAG_OCCLUDING : 0;
-		flags |= canFall ? FLAG_FALLABLE : 0;
 		flags |= isTileEntity ? FLAG_TILE_ENTITY : 0;
 		this.blockFlags[blockId] = flags;
 	}
@@ -48,7 +46,7 @@ public abstract class AbstractNmsManager implements NmsManager {
 
 	@Override
 	public final Set<Integer> getBlockIds(Material material) {
-		return Collections.unmodifiableSet(this.materialToIds.getOrDefault(material, Collections.emptySet()));
+		return Collections.unmodifiableSet(this.materialToIds.get(material));
 	}
 
 	@Override
@@ -59,11 +57,6 @@ public abstract class AbstractNmsManager implements NmsManager {
 	@Override
 	public final boolean isOccluding(int blockId) {
 		return (this.blockFlags[blockId] & FLAG_OCCLUDING) != 0;
-	}
-
-	@Override
-	public boolean isFallable(int blockId) {
-		return (this.blockFlags[blockId] & FLAG_FALLABLE) != 0;
 	}
 
 	@Override

--- a/orebfuscator-nms/orebfuscator-nms-api/src/main/java/net/imprex/orebfuscator/nms/NmsManager.java
+++ b/orebfuscator-nms/orebfuscator-nms-api/src/main/java/net/imprex/orebfuscator/nms/NmsManager.java
@@ -27,8 +27,6 @@ public interface NmsManager {
 
 	boolean isOccluding(int blockId);
 
-	boolean isFallable(int blockId);
-
 	boolean isBlockEntity(int blockId);
 
 	ReadOnlyChunk getReadOnlyChunk(World world, int chunkX, int chunkZ);

--- a/orebfuscator-nms/orebfuscator-nms-v1_10_R1/src/main/java/net/imprex/orebfuscator/nms/v1_10_R1/NmsManager.java
+++ b/orebfuscator-nms/orebfuscator-nms-v1_10_R1/src/main/java/net/imprex/orebfuscator/nms/v1_10_R1/NmsManager.java
@@ -18,7 +18,6 @@ import net.imprex.orebfuscator.nms.AbstractRegionFileCache;
 import net.imprex.orebfuscator.nms.ReadOnlyChunk;
 import net.minecraft.server.v1_10_R1.Block;
 import net.minecraft.server.v1_10_R1.BlockAir;
-import net.minecraft.server.v1_10_R1.BlockFalling;
 import net.minecraft.server.v1_10_R1.BlockPosition;
 import net.minecraft.server.v1_10_R1.Chunk;
 import net.minecraft.server.v1_10_R1.ChunkProviderServer;
@@ -74,7 +73,7 @@ public class NmsManager extends AbstractNmsManager {
 			int blockId = getBlockId(blockData);
 			this.registerMaterialId(material, blockId);
 			Block block = blockData.getBlock();
-			this.setBlockFlags(blockId, block instanceof BlockAir, material.isOccluding(), block instanceof BlockFalling, block.isTileEntity());
+			this.setBlockFlags(blockId, block instanceof BlockAir, material.isOccluding(), block.isTileEntity());
 		}
 	}
 

--- a/orebfuscator-nms/orebfuscator-nms-v1_11_R1/src/main/java/net/imprex/orebfuscator/nms/v1_11_R1/NmsManager.java
+++ b/orebfuscator-nms/orebfuscator-nms-v1_11_R1/src/main/java/net/imprex/orebfuscator/nms/v1_11_R1/NmsManager.java
@@ -18,7 +18,6 @@ import net.imprex.orebfuscator.nms.AbstractRegionFileCache;
 import net.imprex.orebfuscator.nms.ReadOnlyChunk;
 import net.minecraft.server.v1_11_R1.Block;
 import net.minecraft.server.v1_11_R1.BlockAir;
-import net.minecraft.server.v1_11_R1.BlockFalling;
 import net.minecraft.server.v1_11_R1.BlockPosition;
 import net.minecraft.server.v1_11_R1.Chunk;
 import net.minecraft.server.v1_11_R1.ChunkProviderServer;
@@ -74,7 +73,7 @@ public class NmsManager extends AbstractNmsManager {
 			int blockId = getBlockId(blockData);
 			this.registerMaterialId(material, blockId);
 			Block block = blockData.getBlock();
-			this.setBlockFlags(blockId, block instanceof BlockAir, material.isOccluding(), block instanceof BlockFalling, block.isTileEntity());
+			this.setBlockFlags(blockId, block instanceof BlockAir, material.isOccluding(), block.isTileEntity());
 		}
 	}
 

--- a/orebfuscator-nms/orebfuscator-nms-v1_12_R1/src/main/java/net/imprex/orebfuscator/nms/v1_12_R1/NmsManager.java
+++ b/orebfuscator-nms/orebfuscator-nms-v1_12_R1/src/main/java/net/imprex/orebfuscator/nms/v1_12_R1/NmsManager.java
@@ -18,7 +18,6 @@ import net.imprex.orebfuscator.nms.AbstractRegionFileCache;
 import net.imprex.orebfuscator.nms.ReadOnlyChunk;
 import net.minecraft.server.v1_12_R1.Block;
 import net.minecraft.server.v1_12_R1.BlockAir;
-import net.minecraft.server.v1_12_R1.BlockFalling;
 import net.minecraft.server.v1_12_R1.BlockPosition;
 import net.minecraft.server.v1_12_R1.Chunk;
 import net.minecraft.server.v1_12_R1.ChunkProviderServer;
@@ -74,7 +73,7 @@ public class NmsManager extends AbstractNmsManager {
 			int blockId = getBlockId(blockData);
 			this.registerMaterialId(material, blockId);
 			Block block = blockData.getBlock();
-			this.setBlockFlags(blockId, block instanceof BlockAir, material.isOccluding(), block instanceof BlockFalling, block.isTileEntity());
+			this.setBlockFlags(blockId, block instanceof BlockAir, material.isOccluding(), block.isTileEntity());
 		}
 	}
 

--- a/orebfuscator-nms/orebfuscator-nms-v1_13_R1/src/main/java/net/imprex/orebfuscator/nms/v1_13_R1/NmsManager.java
+++ b/orebfuscator-nms/orebfuscator-nms-v1_13_R1/src/main/java/net/imprex/orebfuscator/nms/v1_13_R1/NmsManager.java
@@ -18,7 +18,6 @@ import net.imprex.orebfuscator.nms.AbstractNmsManager;
 import net.imprex.orebfuscator.nms.AbstractRegionFileCache;
 import net.imprex.orebfuscator.nms.ReadOnlyChunk;
 import net.minecraft.server.v1_13_R1.Block;
-import net.minecraft.server.v1_13_R1.BlockFalling;
 import net.minecraft.server.v1_13_R1.BlockPosition;
 import net.minecraft.server.v1_13_R1.Chunk;
 import net.minecraft.server.v1_13_R1.ChunkProviderServer;
@@ -72,9 +71,8 @@ public class NmsManager extends AbstractNmsManager {
 			IBlockData blockData = iterator.next();
 			Material material = CraftBlockData.fromData(blockData).getMaterial();
 			int blockId = getBlockId(blockData);
-			Block block = blockData.getBlock();
 			this.registerMaterialId(material, blockId);
-			this.setBlockFlags(blockId, blockData.isAir(), material.isOccluding(), block instanceof BlockFalling, blockData.getBlock().isTileEntity());
+			this.setBlockFlags(blockId, blockData.isAir(), material.isOccluding(), blockData.getBlock().isTileEntity());
 		}
 	}
 

--- a/orebfuscator-nms/orebfuscator-nms-v1_13_R2/src/main/java/net/imprex/orebfuscator/nms/v1_13_R2/NmsManager.java
+++ b/orebfuscator-nms/orebfuscator-nms-v1_13_R2/src/main/java/net/imprex/orebfuscator/nms/v1_13_R2/NmsManager.java
@@ -18,7 +18,6 @@ import net.imprex.orebfuscator.nms.AbstractNmsManager;
 import net.imprex.orebfuscator.nms.AbstractRegionFileCache;
 import net.imprex.orebfuscator.nms.ReadOnlyChunk;
 import net.minecraft.server.v1_13_R2.Block;
-import net.minecraft.server.v1_13_R2.BlockFalling;
 import net.minecraft.server.v1_13_R2.BlockPosition;
 import net.minecraft.server.v1_13_R2.Chunk;
 import net.minecraft.server.v1_13_R2.ChunkProviderServer;
@@ -73,9 +72,8 @@ public class NmsManager extends AbstractNmsManager {
 			IBlockData blockData = iterator.next();
 			Material material = CraftBlockData.fromData(blockData).getMaterial();
 			int blockId = getBlockId(blockData);
-			Block block = blockData.getBlock();
 			this.registerMaterialId(material, blockId);
-			this.setBlockFlags(blockId, blockData.isAir(), material.isOccluding(), block instanceof BlockFalling, blockData.getBlock().isTileEntity());
+			this.setBlockFlags(blockId, blockData.isAir(), material.isOccluding(), blockData.getBlock().isTileEntity());
 		}
 	}
 

--- a/orebfuscator-nms/orebfuscator-nms-v1_14_R1/src/main/java/net/imprex/orebfuscator/nms/v1_14_R1/NmsManager.java
+++ b/orebfuscator-nms/orebfuscator-nms-v1_14_R1/src/main/java/net/imprex/orebfuscator/nms/v1_14_R1/NmsManager.java
@@ -17,7 +17,6 @@ import net.imprex.orebfuscator.nms.AbstractNmsManager;
 import net.imprex.orebfuscator.nms.AbstractRegionFileCache;
 import net.imprex.orebfuscator.nms.ReadOnlyChunk;
 import net.minecraft.server.v1_14_R1.Block;
-import net.minecraft.server.v1_14_R1.BlockFalling;
 import net.minecraft.server.v1_14_R1.BlockPosition;
 import net.minecraft.server.v1_14_R1.Chunk;
 import net.minecraft.server.v1_14_R1.ChunkProviderServer;
@@ -71,9 +70,8 @@ public class NmsManager extends AbstractNmsManager {
 		for (IBlockData blockData : Block.REGISTRY_ID) {
 			Material material = CraftBlockData.fromData(blockData).getMaterial();
 			int blockId = getBlockId(blockData);
-			Block block = blockData.getBlock();
 			this.registerMaterialId(material, blockId);
-			this.setBlockFlags(blockId, blockData.isAir(), material.isOccluding(), block instanceof BlockFalling, blockData.getBlock().isTileEntity());
+			this.setBlockFlags(blockId, blockData.isAir(), material.isOccluding(), blockData.getBlock().isTileEntity());
 		}
 	}
 

--- a/orebfuscator-nms/orebfuscator-nms-v1_15_R1/src/main/java/net/imprex/orebfuscator/nms/v1_15_R1/NmsManager.java
+++ b/orebfuscator-nms/orebfuscator-nms-v1_15_R1/src/main/java/net/imprex/orebfuscator/nms/v1_15_R1/NmsManager.java
@@ -17,7 +17,6 @@ import net.imprex.orebfuscator.nms.AbstractNmsManager;
 import net.imprex.orebfuscator.nms.AbstractRegionFileCache;
 import net.imprex.orebfuscator.nms.ReadOnlyChunk;
 import net.minecraft.server.v1_15_R1.Block;
-import net.minecraft.server.v1_15_R1.BlockFalling;
 import net.minecraft.server.v1_15_R1.BlockPosition;
 import net.minecraft.server.v1_15_R1.Chunk;
 import net.minecraft.server.v1_15_R1.ChunkProviderServer;
@@ -71,9 +70,8 @@ public class NmsManager extends AbstractNmsManager {
 		for (IBlockData blockData : Block.REGISTRY_ID) {
 			Material material = CraftBlockData.fromData(blockData).getMaterial();
 			int blockId = getBlockId(blockData);
-			Block block = blockData.getBlock();
 			this.registerMaterialId(material, blockId);
-			this.setBlockFlags(blockId, blockData.isAir(), material.isOccluding(), block instanceof BlockFalling, blockData.getBlock().isTileEntity());
+			this.setBlockFlags(blockId, blockData.isAir(), material.isOccluding(), blockData.getBlock().isTileEntity());
 		}
 	}
 

--- a/orebfuscator-nms/orebfuscator-nms-v1_16_R1/src/main/java/net/imprex/orebfuscator/nms/v1_16_R1/NmsManager.java
+++ b/orebfuscator-nms/orebfuscator-nms-v1_16_R1/src/main/java/net/imprex/orebfuscator/nms/v1_16_R1/NmsManager.java
@@ -17,7 +17,6 @@ import net.imprex.orebfuscator.nms.AbstractNmsManager;
 import net.imprex.orebfuscator.nms.AbstractRegionFileCache;
 import net.imprex.orebfuscator.nms.ReadOnlyChunk;
 import net.minecraft.server.v1_16_R1.Block;
-import net.minecraft.server.v1_16_R1.BlockFalling;
 import net.minecraft.server.v1_16_R1.BlockPosition;
 import net.minecraft.server.v1_16_R1.Chunk;
 import net.minecraft.server.v1_16_R1.ChunkProviderServer;
@@ -71,9 +70,8 @@ public class NmsManager extends AbstractNmsManager {
 		for (IBlockData blockData : Block.REGISTRY_ID) {
 			Material material = CraftBlockData.fromData(blockData).getMaterial();
 			int blockId = getBlockId(blockData);
-			Block block = blockData.getBlock();
 			this.registerMaterialId(material, blockId);
-			this.setBlockFlags(blockId, blockData.isAir(), material.isOccluding(), block instanceof BlockFalling, blockData.getBlock().isTileEntity());
+			this.setBlockFlags(blockId, blockData.isAir(), material.isOccluding(), blockData.getBlock().isTileEntity());
 		}
 	}
 

--- a/orebfuscator-nms/orebfuscator-nms-v1_16_R2/src/main/java/net/imprex/orebfuscator/nms/v1_16_R2/NmsManager.java
+++ b/orebfuscator-nms/orebfuscator-nms-v1_16_R2/src/main/java/net/imprex/orebfuscator/nms/v1_16_R2/NmsManager.java
@@ -17,7 +17,6 @@ import net.imprex.orebfuscator.nms.AbstractNmsManager;
 import net.imprex.orebfuscator.nms.AbstractRegionFileCache;
 import net.imprex.orebfuscator.nms.ReadOnlyChunk;
 import net.minecraft.server.v1_16_R2.Block;
-import net.minecraft.server.v1_16_R2.BlockFalling;
 import net.minecraft.server.v1_16_R2.BlockPosition;
 import net.minecraft.server.v1_16_R2.Chunk;
 import net.minecraft.server.v1_16_R2.ChunkProviderServer;
@@ -71,9 +70,8 @@ public class NmsManager extends AbstractNmsManager {
 		for (IBlockData blockData : Block.REGISTRY_ID) {
 			Material material = CraftBlockData.fromData(blockData).getMaterial();
 			int blockId = getBlockId(blockData);
-			Block block = blockData.getBlock();
 			this.registerMaterialId(material, blockId);
-			this.setBlockFlags(blockId, blockData.isAir(), material.isOccluding(), block instanceof BlockFalling, blockData.getBlock().isTileEntity());
+			this.setBlockFlags(blockId, blockData.isAir(), material.isOccluding(), blockData.getBlock().isTileEntity());
 		}
 	}
 

--- a/orebfuscator-nms/orebfuscator-nms-v1_16_R3/src/main/java/net/imprex/orebfuscator/nms/v1_16_R3/NmsManager.java
+++ b/orebfuscator-nms/orebfuscator-nms-v1_16_R3/src/main/java/net/imprex/orebfuscator/nms/v1_16_R3/NmsManager.java
@@ -17,7 +17,6 @@ import net.imprex.orebfuscator.nms.AbstractNmsManager;
 import net.imprex.orebfuscator.nms.AbstractRegionFileCache;
 import net.imprex.orebfuscator.nms.ReadOnlyChunk;
 import net.minecraft.server.v1_16_R3.Block;
-import net.minecraft.server.v1_16_R3.BlockFalling;
 import net.minecraft.server.v1_16_R3.BlockPosition;
 import net.minecraft.server.v1_16_R3.Chunk;
 import net.minecraft.server.v1_16_R3.ChunkProviderServer;
@@ -71,9 +70,8 @@ public class NmsManager extends AbstractNmsManager {
 		for (IBlockData blockData : Block.REGISTRY_ID) {
 			Material material = CraftBlockData.fromData(blockData).getMaterial();
 			int blockId = getBlockId(blockData);
-			Block block = blockData.getBlock();
 			this.registerMaterialId(material, blockId);
-			this.setBlockFlags(blockId, blockData.isAir(), material.isOccluding(), block instanceof BlockFalling, blockData.getBlock().isTileEntity());
+			this.setBlockFlags(blockId, blockData.isAir(), material.isOccluding(), blockData.getBlock().isTileEntity());
 		}
 	}
 

--- a/orebfuscator-nms/orebfuscator-nms-v1_17_R1/src/main/java/net/imprex/orebfuscator/nms/v1_17_R1/NmsManager.java
+++ b/orebfuscator-nms/orebfuscator-nms-v1_17_R1/src/main/java/net/imprex/orebfuscator/nms/v1_17_R1/NmsManager.java
@@ -25,7 +25,6 @@ import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.util.Mth;
 import net.minecraft.world.level.block.Block;
-import net.minecraft.world.level.block.Fallable;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.chunk.LevelChunk;
@@ -71,9 +70,8 @@ public class NmsManager extends AbstractNmsManager {
 		for (BlockState blockData : Block.BLOCK_STATE_REGISTRY) {
 			Material material = CraftBlockData.fromData(blockData).getMaterial();
 			int blockId = getBlockId(blockData);
-			Block block = blockData.getBlock();
 			this.registerMaterialId(material, blockId);
-			this.setBlockFlags(blockId, blockData.isAir(), material.isOccluding(), block instanceof Fallable, blockData.hasBlockEntity());
+			this.setBlockFlags(blockId, blockData.isAir(), material.isOccluding(), blockData.hasBlockEntity());
 		}
 	}
 

--- a/orebfuscator-nms/orebfuscator-nms-v1_18_R1/src/main/java/net/imprex/orebfuscator/nms/v1_18_R1/NmsManager.java
+++ b/orebfuscator-nms/orebfuscator-nms-v1_18_R1/src/main/java/net/imprex/orebfuscator/nms/v1_18_R1/NmsManager.java
@@ -25,7 +25,6 @@ import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.util.Mth;
 import net.minecraft.world.level.block.Block;
-import net.minecraft.world.level.block.Fallable;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.chunk.LevelChunk;
@@ -71,9 +70,8 @@ public class NmsManager extends AbstractNmsManager {
 		for (BlockState blockData : Block.BLOCK_STATE_REGISTRY) {
 			Material material = CraftBlockData.fromData(blockData).getMaterial();
 			int blockId = getBlockId(blockData);
-			Block block = blockData.getBlock();
 			this.registerMaterialId(material, blockId);
-			this.setBlockFlags(blockId, blockData.isAir(), material.isOccluding(), block instanceof Fallable, blockData.hasBlockEntity());
+			this.setBlockFlags(blockId, blockData.isAir(), material.isOccluding(), blockData.hasBlockEntity());
 		}
 	}
 

--- a/orebfuscator-nms/orebfuscator-nms-v1_18_R2/src/main/java/net/imprex/orebfuscator/nms/v1_18_R2/NmsManager.java
+++ b/orebfuscator-nms/orebfuscator-nms-v1_18_R2/src/main/java/net/imprex/orebfuscator/nms/v1_18_R2/NmsManager.java
@@ -25,7 +25,6 @@ import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.util.Mth;
 import net.minecraft.world.level.block.Block;
-import net.minecraft.world.level.block.Fallable;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.chunk.LevelChunk;
@@ -71,9 +70,8 @@ public class NmsManager extends AbstractNmsManager {
 		for (BlockState blockData : Block.BLOCK_STATE_REGISTRY) {
 			Material material = CraftBlockData.fromData(blockData).getMaterial();
 			int blockId = getBlockId(blockData);
-			Block block = blockData.getBlock();
 			this.registerMaterialId(material, blockId);
-			this.setBlockFlags(blockId, blockData.isAir(), material.isOccluding(), block instanceof Fallable, blockData.hasBlockEntity());
+			this.setBlockFlags(blockId, blockData.isAir(), material.isOccluding(), blockData.hasBlockEntity());
 		}
 	}
 

--- a/orebfuscator-nms/orebfuscator-nms-v1_9_R2/src/main/java/net/imprex/orebfuscator/nms/v1_9_R2/NmsManager.java
+++ b/orebfuscator-nms/orebfuscator-nms-v1_9_R2/src/main/java/net/imprex/orebfuscator/nms/v1_9_R2/NmsManager.java
@@ -18,7 +18,6 @@ import net.imprex.orebfuscator.nms.AbstractRegionFileCache;
 import net.imprex.orebfuscator.nms.ReadOnlyChunk;
 import net.minecraft.server.v1_9_R2.Block;
 import net.minecraft.server.v1_9_R2.BlockAir;
-import net.minecraft.server.v1_9_R2.BlockFalling;
 import net.minecraft.server.v1_9_R2.BlockPosition;
 import net.minecraft.server.v1_9_R2.Chunk;
 import net.minecraft.server.v1_9_R2.ChunkProviderServer;
@@ -74,7 +73,7 @@ public class NmsManager extends AbstractNmsManager {
 			int blockId = getBlockId(blockData);
 			this.registerMaterialId(material, blockId);
 			Block block = blockData.getBlock();
-			this.setBlockFlags(blockId, block instanceof BlockAir, material.isOccluding(), block instanceof BlockFalling, block.isTileEntity());
+			this.setBlockFlags(blockId, block instanceof BlockAir, material.isOccluding(), block.isTileEntity());
 		}
 	}
 

--- a/orebfuscator-plugin/src/main/java/net/imprex/orebfuscator/NmsInstance.java
+++ b/orebfuscator-plugin/src/main/java/net/imprex/orebfuscator/NmsInstance.java
@@ -86,10 +86,6 @@ public class NmsInstance {
 		return instance.isOccluding(blockId);
 	}
 
-	public static boolean isFallable(int blockId) {
-		return instance.isFallable(blockId);
-	}
-
 	public static boolean isBlockEntity(int blockId) {
 		return instance.isBlockEntity(blockId);
 	}

--- a/orebfuscator-plugin/src/main/java/net/imprex/orebfuscator/obfuscation/DeobfuscationListener.java
+++ b/orebfuscator-plugin/src/main/java/net/imprex/orebfuscator/obfuscation/DeobfuscationListener.java
@@ -14,7 +14,6 @@ import org.bukkit.event.block.BlockPistonExtendEvent;
 import org.bukkit.event.block.BlockPistonRetractEvent;
 import org.bukkit.event.entity.EntityChangeBlockEvent;
 import org.bukkit.event.entity.EntityExplodeEvent;
-import org.bukkit.event.entity.EntityInteractEvent;
 import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.event.player.PlayerJoinEvent;
 
@@ -76,11 +75,6 @@ public class DeobfuscationListener implements Listener {
 	@EventHandler
 	public void onEntityExplode(EntityExplodeEvent event) {
 		this.deobfuscationWorker.deobfuscate(event.blockList(), true);
-	}
-
-	@EventHandler
-	public void onEntityInteract(EntityInteractEvent event) {
-		this.deobfuscationWorker.deobfuscate(event.getBlock());
 	}
 
 	@EventHandler

--- a/orebfuscator-plugin/src/main/java/net/imprex/orebfuscator/obfuscation/DeobfuscationListener.java
+++ b/orebfuscator-plugin/src/main/java/net/imprex/orebfuscator/obfuscation/DeobfuscationListener.java
@@ -1,9 +1,6 @@
 package net.imprex.orebfuscator.obfuscation;
 
-import java.util.BitSet;
-
 import org.bukkit.Bukkit;
-import org.bukkit.Material;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Event.Result;
 import org.bukkit.event.EventHandler;
@@ -13,7 +10,6 @@ import org.bukkit.event.block.BlockBreakEvent;
 import org.bukkit.event.block.BlockBurnEvent;
 import org.bukkit.event.block.BlockDamageEvent;
 import org.bukkit.event.block.BlockExplodeEvent;
-import org.bukkit.event.block.BlockPhysicsEvent;
 import org.bukkit.event.block.BlockPistonExtendEvent;
 import org.bukkit.event.block.BlockPistonRetractEvent;
 import org.bukkit.event.entity.EntityChangeBlockEvent;
@@ -39,20 +35,10 @@ public class DeobfuscationListener implements Listener {
 	private final OrebfuscatorConfig config;
 	private final DeobfuscationWorker deobfuscationWorker;
 
-	private final BitSet occludingFallable = new BitSet();
-
 	private DeobfuscationListener(Orebfuscator orebfuscator, DeobfuscationWorker deobfuscationWorker) {
 		this.updateSystem = orebfuscator.getUpdateSystem();
 		this.config = orebfuscator.getOrebfuscatorConfig();
 		this.deobfuscationWorker = deobfuscationWorker;
-
-		for (Material material : Material.values()) {
-			for (int blockId : NmsInstance.getBlockIds(material)) {
-				if (NmsInstance.isFallable(blockId) && NmsInstance.isOccluding(blockId)) {
-					this.occludingFallable.set(material.ordinal());
-				}
-			}
-		}
 	}
 
 	@EventHandler
@@ -85,13 +71,6 @@ public class DeobfuscationListener implements Listener {
 	@EventHandler
 	public void onBlockPistonRetract(BlockPistonRetractEvent event) {
 		this.deobfuscationWorker.deobfuscate(event.getBlocks(), true);
-	}
-
-	@EventHandler
-	public void onBlockPhysics(BlockPhysicsEvent event) {
-		if (this.occludingFallable.get(event.getBlock().getType().ordinal())) {
-			this.deobfuscationWorker.deobfuscate(event.getBlock());
-		}
 	}
 
 	@EventHandler


### PR DESCRIPTION
## Description
Remove BlockPhysicsEvent and EntityInteractEvent in favor of EntityChangeBlockEvent.

## Related Issue
closes #210

## How Has This Been Tested?
Successfully tested on latest spigot build.

## Types of Changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
