### PR TITLE
fix codemc jdk8

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Still having trouble getting Orebfuscator to run check out our [common issues](h
 ## License:
 
 Almost completely rewritten by Imprex-Development to support v1.14 and higher Minecraft version's; these portions as permissible:
-Copyright (C) 2020-2021 by Imprex-Development. All rights reserved.
+Copyright (C) 2020-2022 by Imprex-Development. All rights reserved.
 
 Released under the same license as original.
 

--- a/orebfuscator-plugin/pom.xml
+++ b/orebfuscator-plugin/pom.xml
@@ -47,7 +47,7 @@
 			<groupId>net.imprex</groupId>
 			<artifactId>orebfuscator-common</artifactId>
 			<version>${revision}</version>
-			<scope>compile</scope>
+			<scope>provided</scope>
 		</dependency>
 		<dependency>
 			<groupId>net.imprex</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -17,12 +17,13 @@
 		<dependency.protocollib.version>4.4.0</dependency.protocollib.version>
 		<dependency.bstats.version>3.0.0</dependency.bstats.version>
 
+		<plugin.compile.version>3.10.1</plugin.compile.version>
 		<plugin.shade.version>3.3.0</plugin.shade.version>
 		<plugin.flatten.version>1.2.7</plugin.flatten.version>
 		<plugin.specialsource.version>1.2.4</plugin.specialsource.version>
 
-		<maven.compiler.source>1.8</maven.compiler.source>
-		<maven.compiler.target>1.8</maven.compiler.target>
+		<maven.compiler.sourceD>1.8</maven.compiler.sourceD>
+		<maven.compiler.targetD>1.8</maven.compiler.targetD>
 
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 	</properties>
@@ -46,6 +47,14 @@
 			</resource>
 		</resources>
 		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<version>${plugin.compile.version}</version>
+				<configuration>
+					<release>8</release>
+				</configuration>
+			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-shade-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,14 @@
 	<packaging>pom</packaging>
 
 	<name>Orebfuscator</name>
+	<url>https://github.com/Imprex-Development/Orebfuscator</url>
 	<description>High-Performance Anti X-Ray</description>
+	<inceptionYear>2020</inceptionYear>
+
+	<issueManagement>
+		<system>GitHub</system>
+		<url>https://github.com/Imprex-Development/Orebfuscator/issues</url>
+	</issueManagement>
 
 	<properties>
 		<revision>5.0.0-b0</revision>
@@ -21,9 +28,6 @@
 		<plugin.shade.version>3.3.0</plugin.shade.version>
 		<plugin.flatten.version>1.2.7</plugin.flatten.version>
 		<plugin.specialsource.version>1.2.4</plugin.specialsource.version>
-
-		<maven.compiler.sourceD>1.8</maven.compiler.sourceD>
-		<maven.compiler.targetD>1.8</maven.compiler.targetD>
 
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 	</properties>
@@ -59,14 +63,6 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-shade-plugin</artifactId>
 				<version>${plugin.shade.version}</version>
-				<configuration>
-					<relocations>
-						<relocation>
-							<pattern>org.bstats</pattern>
-							<shadedPattern>net.imprex.orebfuscator.metrics</shadedPattern>
-						</relocation>
-					</relocations>
-				</configuration>
 				<executions>
 					<execution>
 						<phase>package</phase>
@@ -75,6 +71,24 @@
 						</goals>
 					</execution>
 				</executions>
+				<configuration>
+					<relocations>
+						<relocation>
+							<pattern>org.bstats</pattern>
+							<shadedPattern>net.imprex.orebfuscator.metrics</shadedPattern>
+						</relocation>
+					</relocations>
+					<filters>
+						<filter>
+							<artifact>*:*</artifact>
+							<excludes>
+								<exclude>META-INF/*.SF</exclude>
+								<exclude>META-INF/*.DSA</exclude>
+								<exclude>META-INF/*.RSA</exclude>
+							</excludes>
+						</filter>
+					</filters>
+				</configuration>
 			</plugin>
 			<plugin>
 				<groupId>org.codehaus.mojo</groupId>


### PR DESCRIPTION
## Description
Set the release target to jdk8 to allow the usage of the latest jenkins versions.

## How Has This Been Tested?
Successfully tested with latest spigot version

## Types of Changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
