### PR TITLE
[#248] Fix invalid block occlusion flags

### DIFF
--- a/orebfuscator-nms/orebfuscator-nms-v1_12_R1/src/main/java/net/imprex/orebfuscator/nms/v1_12_R1/NmsManager.java
+++ b/orebfuscator-nms/orebfuscator-nms-v1_12_R1/src/main/java/net/imprex/orebfuscator/nms/v1_12_R1/NmsManager.java
@@ -73,7 +73,11 @@ public class NmsManager extends AbstractNmsManager {
 			int blockId = getBlockId(blockData);
 			this.registerMaterialId(material, blockId);
 			Block block = blockData.getBlock();
-			this.setBlockFlags(blockId, block instanceof BlockAir, material.isOccluding(), block.isTileEntity());
+			/**
+			 * p -> for barrier/slime_block/spawner
+			 * r -> for every other block
+			 */
+			this.setBlockFlags(blockId, block instanceof BlockAir, blockData.p() && blockData.r()/*canOcclude*/, block.isTileEntity());
 		}
 	}
 

--- a/orebfuscator-nms/orebfuscator-nms-v1_13_R1/src/main/java/net/imprex/orebfuscator/nms/v1_13_R1/NmsManager.java
+++ b/orebfuscator-nms/orebfuscator-nms-v1_13_R1/src/main/java/net/imprex/orebfuscator/nms/v1_13_R1/NmsManager.java
@@ -72,7 +72,11 @@ public class NmsManager extends AbstractNmsManager {
 			Material material = CraftBlockData.fromData(blockData).getMaterial();
 			int blockId = getBlockId(blockData);
 			this.registerMaterialId(material, blockId);
-			this.setBlockFlags(blockId, blockData.isAir(), material.isOccluding(), blockData.getBlock().isTileEntity());
+			/**
+			 * p -> for barrier/slime_block/spawner
+			 * r -> for every other block
+			 */
+			this.setBlockFlags(blockId, blockData.isAir(), blockData.p() && blockData.r()/*canOcclude*/, blockData.getBlock().isTileEntity());
 		}
 	}
 

--- a/orebfuscator-nms/orebfuscator-nms-v1_13_R2/src/main/java/net/imprex/orebfuscator/nms/v1_13_R2/NmsManager.java
+++ b/orebfuscator-nms/orebfuscator-nms-v1_13_R2/src/main/java/net/imprex/orebfuscator/nms/v1_13_R2/NmsManager.java
@@ -73,7 +73,11 @@ public class NmsManager extends AbstractNmsManager {
 			Material material = CraftBlockData.fromData(blockData).getMaterial();
 			int blockId = getBlockId(blockData);
 			this.registerMaterialId(material, blockId);
-			this.setBlockFlags(blockId, blockData.isAir(), material.isOccluding(), blockData.getBlock().isTileEntity());
+			/**
+			 * p -> for barrier/slime_block/spawner
+			 * r -> for every other block
+			 */
+			this.setBlockFlags(blockId, blockData.isAir(), blockData.p() && blockData.r()/*canOcclude*/, blockData.getBlock().isTileEntity());
 		}
 	}
 

--- a/orebfuscator-nms/orebfuscator-nms-v1_14_R1/src/main/java/net/imprex/orebfuscator/nms/v1_14_R1/NmsManager.java
+++ b/orebfuscator-nms/orebfuscator-nms-v1_14_R1/src/main/java/net/imprex/orebfuscator/nms/v1_14_R1/NmsManager.java
@@ -71,7 +71,11 @@ public class NmsManager extends AbstractNmsManager {
 			Material material = CraftBlockData.fromData(blockData).getMaterial();
 			int blockId = getBlockId(blockData);
 			this.registerMaterialId(material, blockId);
-			this.setBlockFlags(blockId, blockData.isAir(), material.isOccluding(), blockData.getBlock().isTileEntity());
+			/**
+			 * o -> for barrier/slime_block/spawner/leaves
+			 * isOccluding -> for every other block
+			 */
+			this.setBlockFlags(blockId, blockData.isAir(), material.isOccluding() && blockData.o()/*canOcclude*/, blockData.getBlock().isTileEntity());
 		}
 	}
 

--- a/orebfuscator-nms/orebfuscator-nms-v1_15_R1/src/main/java/net/imprex/orebfuscator/nms/v1_15_R1/NmsManager.java
+++ b/orebfuscator-nms/orebfuscator-nms-v1_15_R1/src/main/java/net/imprex/orebfuscator/nms/v1_15_R1/NmsManager.java
@@ -71,7 +71,11 @@ public class NmsManager extends AbstractNmsManager {
 			Material material = CraftBlockData.fromData(blockData).getMaterial();
 			int blockId = getBlockId(blockData);
 			this.registerMaterialId(material, blockId);
-			this.setBlockFlags(blockId, blockData.isAir(), material.isOccluding(), blockData.getBlock().isTileEntity());
+			/**
+			 * o -> for barrier/slime_block/spawner/leaves
+			 * isOccluding -> for every other block
+			 */
+			this.setBlockFlags(blockId, blockData.isAir(), material.isOccluding() && blockData.o()/*canOcclude*/, blockData.getBlock().isTileEntity());
 		}
 	}
 

--- a/orebfuscator-nms/orebfuscator-nms-v1_16_R1/src/main/java/net/imprex/orebfuscator/nms/v1_16_R1/NmsManager.java
+++ b/orebfuscator-nms/orebfuscator-nms-v1_16_R1/src/main/java/net/imprex/orebfuscator/nms/v1_16_R1/NmsManager.java
@@ -71,7 +71,11 @@ public class NmsManager extends AbstractNmsManager {
 			Material material = CraftBlockData.fromData(blockData).getMaterial();
 			int blockId = getBlockId(blockData);
 			this.registerMaterialId(material, blockId);
-			this.setBlockFlags(blockId, blockData.isAir(), material.isOccluding(), blockData.getBlock().isTileEntity());
+			/**
+			 * l -> for barrier/slime_block/spawner/leaves
+			 * isOccluding -> for every other block
+			 */
+			this.setBlockFlags(blockId, blockData.isAir(), material.isOccluding() && blockData.l()/*canOcclude*/, blockData.getBlock().isTileEntity());
 		}
 	}
 

--- a/orebfuscator-nms/orebfuscator-nms-v1_16_R2/src/main/java/net/imprex/orebfuscator/nms/v1_16_R2/NmsManager.java
+++ b/orebfuscator-nms/orebfuscator-nms-v1_16_R2/src/main/java/net/imprex/orebfuscator/nms/v1_16_R2/NmsManager.java
@@ -71,7 +71,11 @@ public class NmsManager extends AbstractNmsManager {
 			Material material = CraftBlockData.fromData(blockData).getMaterial();
 			int blockId = getBlockId(blockData);
 			this.registerMaterialId(material, blockId);
-			this.setBlockFlags(blockId, blockData.isAir(), material.isOccluding(), blockData.getBlock().isTileEntity());
+			/**
+			 * l -> for barrier/slime_block/spawner/leaves
+			 * isOccluding -> for every other block
+			 */
+			this.setBlockFlags(blockId, blockData.isAir(), material.isOccluding() && blockData.l()/*canOcclude*/, blockData.getBlock().isTileEntity());
 		}
 	}
 

--- a/orebfuscator-nms/orebfuscator-nms-v1_16_R3/src/main/java/net/imprex/orebfuscator/nms/v1_16_R3/NmsManager.java
+++ b/orebfuscator-nms/orebfuscator-nms-v1_16_R3/src/main/java/net/imprex/orebfuscator/nms/v1_16_R3/NmsManager.java
@@ -71,7 +71,11 @@ public class NmsManager extends AbstractNmsManager {
 			Material material = CraftBlockData.fromData(blockData).getMaterial();
 			int blockId = getBlockId(blockData);
 			this.registerMaterialId(material, blockId);
-			this.setBlockFlags(blockId, blockData.isAir(), material.isOccluding(), blockData.getBlock().isTileEntity());
+			/**
+			 * l -> for barrier/slime_block/spawner/leaves
+			 * isOccluding -> for every other block
+			 */
+			this.setBlockFlags(blockId, blockData.isAir(), material.isOccluding() && blockData.l()/*canOcclude*/, blockData.getBlock().isTileEntity());
 		}
 	}
 

--- a/orebfuscator-nms/orebfuscator-nms-v1_17_R1/src/main/java/net/imprex/orebfuscator/nms/v1_17_R1/NmsManager.java
+++ b/orebfuscator-nms/orebfuscator-nms-v1_17_R1/src/main/java/net/imprex/orebfuscator/nms/v1_17_R1/NmsManager.java
@@ -71,7 +71,8 @@ public class NmsManager extends AbstractNmsManager {
 			Material material = CraftBlockData.fromData(blockData).getMaterial();
 			int blockId = getBlockId(blockData);
 			this.registerMaterialId(material, blockId);
-			this.setBlockFlags(blockId, blockData.isAir(), material.isOccluding(), blockData.hasBlockEntity());
+			// check if material is occluding and use blockData check for rare edge cases like barrier, spawner, slime_block, ...
+			this.setBlockFlags(blockId, blockData.isAir(), material.isOccluding() && blockData.canOcclude(), blockData.hasBlockEntity());
 		}
 	}
 

--- a/orebfuscator-nms/orebfuscator-nms-v1_18_R1/src/main/java/net/imprex/orebfuscator/nms/v1_18_R1/NmsManager.java
+++ b/orebfuscator-nms/orebfuscator-nms-v1_18_R1/src/main/java/net/imprex/orebfuscator/nms/v1_18_R1/NmsManager.java
@@ -71,7 +71,8 @@ public class NmsManager extends AbstractNmsManager {
 			Material material = CraftBlockData.fromData(blockData).getMaterial();
 			int blockId = getBlockId(blockData);
 			this.registerMaterialId(material, blockId);
-			this.setBlockFlags(blockId, blockData.isAir(), material.isOccluding(), blockData.hasBlockEntity());
+			// check if material is occluding and use blockData check for rare edge cases like barrier, spawner, slime_block, ...
+			this.setBlockFlags(blockId, blockData.isAir(), material.isOccluding() && blockData.canOcclude(), blockData.hasBlockEntity());
 		}
 	}
 

--- a/orebfuscator-nms/orebfuscator-nms-v1_18_R2/src/main/java/net/imprex/orebfuscator/nms/v1_18_R2/NmsManager.java
+++ b/orebfuscator-nms/orebfuscator-nms-v1_18_R2/src/main/java/net/imprex/orebfuscator/nms/v1_18_R2/NmsManager.java
@@ -71,7 +71,8 @@ public class NmsManager extends AbstractNmsManager {
 			Material material = CraftBlockData.fromData(blockData).getMaterial();
 			int blockId = getBlockId(blockData);
 			this.registerMaterialId(material, blockId);
-			this.setBlockFlags(blockId, blockData.isAir(), material.isOccluding(), blockData.hasBlockEntity());
+			// check if material is occluding and use blockData check for rare edge cases like barrier, spawner, slime_block, ...
+			this.setBlockFlags(blockId, blockData.isAir(), material.isOccluding() && blockData.canOcclude(), blockData.hasBlockEntity());
 		}
 	}
 

--- a/orebfuscator-nms/orebfuscator-nms-v1_19_R1/src/main/java/net/imprex/orebfuscator/nms/v1_19_R1/NmsManager.java
+++ b/orebfuscator-nms/orebfuscator-nms-v1_19_R1/src/main/java/net/imprex/orebfuscator/nms/v1_19_R1/NmsManager.java
@@ -71,7 +71,8 @@ public class NmsManager extends AbstractNmsManager {
 			Material material = CraftBlockData.fromData(blockData).getMaterial();
 			int blockId = getBlockId(blockData);
 			this.registerMaterialId(material, blockId);
-			this.setBlockFlags(blockId, blockData.isAir(), material.isOccluding(), blockData.hasBlockEntity());
+			// check if material is occluding and use blockData check for rare edge cases like barrier, spawner, slime_block, ...
+			this.setBlockFlags(blockId, blockData.isAir(), material.isOccluding() && blockData.canOcclude(), blockData.hasBlockEntity());
 		}
 	}
 


### PR DESCRIPTION
## Description
Fix invalid block occlusion flags for barrier, spawner, slime_block and many more.

## Related Issue
closes #248

## How Has This Been Tested?
Tested with every version since 1.12.2

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
