### PR TITLE
Change event priorities to MONITOR

### DIFF
--- a/orebfuscator-plugin/src/main/java/net/imprex/orebfuscator/obfuscation/DeobfuscationListener.java
+++ b/orebfuscator-plugin/src/main/java/net/imprex/orebfuscator/obfuscation/DeobfuscationListener.java
@@ -5,6 +5,7 @@ import org.bukkit.Material;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Event.Result;
 import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.block.Action;
 import org.bukkit.event.block.BlockBreakEvent;
@@ -40,49 +41,49 @@ public class DeobfuscationListener implements Listener {
 		this.deobfuscationWorker = deobfuscationWorker;
 	}
 
-	@EventHandler
+	@EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
 	public void onBlockDamage(BlockDamageEvent event) {
 		if (this.config.general().updateOnBlockDamage()) {
 			this.deobfuscationWorker.deobfuscate(event.getBlock());
 		}
 	}
 
-	@EventHandler
+	@EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
 	public void onBlockBreak(BlockBreakEvent event) {
 		this.deobfuscationWorker.deobfuscate(event.getBlock());
 	}
 
-	@EventHandler
+	@EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
 	public void onBlockBurn(BlockBurnEvent event) {
 		this.deobfuscationWorker.deobfuscate(event.getBlock());
 	}
 
-	@EventHandler
+	@EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
 	public void onBlockExplode(BlockExplodeEvent event) {
 		this.deobfuscationWorker.deobfuscate(event.blockList(), true);
 	}
 
-	@EventHandler
+	@EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
 	public void onBlockPistonExtend(BlockPistonExtendEvent event) {
 		this.deobfuscationWorker.deobfuscate(event.getBlocks(), true);
 	}
 
-	@EventHandler
+	@EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
 	public void onBlockPistonRetract(BlockPistonRetractEvent event) {
 		this.deobfuscationWorker.deobfuscate(event.getBlocks(), true);
 	}
 
-	@EventHandler
+	@EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
 	public void onEntityExplode(EntityExplodeEvent event) {
 		this.deobfuscationWorker.deobfuscate(event.blockList(), true);
 	}
 
-	@EventHandler
+	@EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
 	public void onEntityChangeBlock(EntityChangeBlockEvent event) {
 		this.deobfuscationWorker.deobfuscate(event.getBlock());
 	}
 
-	@EventHandler
+	@EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
 	public void onPlayerInteract(PlayerInteractEvent event) {
 		if (event.getAction() == Action.RIGHT_CLICK_BLOCK && event.useInteractedBlock() != Result.DENY
 				&& event.getItem() != null && event.getItem().getType() != null) {

--- a/orebfuscator-plugin/src/main/java/net/imprex/orebfuscator/obfuscation/DeobfuscationListener.java
+++ b/orebfuscator-plugin/src/main/java/net/imprex/orebfuscator/obfuscation/DeobfuscationListener.java
@@ -41,49 +41,49 @@ public class DeobfuscationListener implements Listener {
 		this.deobfuscationWorker = deobfuscationWorker;
 	}
 
-	@EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+	@EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)
 	public void onBlockDamage(BlockDamageEvent event) {
 		if (this.config.general().updateOnBlockDamage()) {
 			this.deobfuscationWorker.deobfuscate(event.getBlock());
 		}
 	}
 
-	@EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+	@EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)
 	public void onBlockBreak(BlockBreakEvent event) {
 		this.deobfuscationWorker.deobfuscate(event.getBlock());
 	}
 
-	@EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+	@EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)
 	public void onBlockBurn(BlockBurnEvent event) {
 		this.deobfuscationWorker.deobfuscate(event.getBlock());
 	}
 
-	@EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+	@EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)
 	public void onBlockExplode(BlockExplodeEvent event) {
 		this.deobfuscationWorker.deobfuscate(event.blockList(), true);
 	}
 
-	@EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+	@EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)
 	public void onBlockPistonExtend(BlockPistonExtendEvent event) {
 		this.deobfuscationWorker.deobfuscate(event.getBlocks(), true);
 	}
 
-	@EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+	@EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)
 	public void onBlockPistonRetract(BlockPistonRetractEvent event) {
 		this.deobfuscationWorker.deobfuscate(event.getBlocks(), true);
 	}
 
-	@EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+	@EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)
 	public void onEntityExplode(EntityExplodeEvent event) {
 		this.deobfuscationWorker.deobfuscate(event.blockList(), true);
 	}
 
-	@EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+	@EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)
 	public void onEntityChangeBlock(EntityChangeBlockEvent event) {
 		this.deobfuscationWorker.deobfuscate(event.getBlock());
 	}
 
-	@EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+	@EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)
 	public void onPlayerInteract(PlayerInteractEvent event) {
 		if (event.getAction() == Action.RIGHT_CLICK_BLOCK && event.useInteractedBlock() != Result.DENY
 				&& event.getItem() != null && event.getItem().getType() != null) {

--- a/orebfuscator-plugin/src/main/java/net/imprex/orebfuscator/proximity/ProximityDirectorThread.java
+++ b/orebfuscator-plugin/src/main/java/net/imprex/orebfuscator/proximity/ProximityDirectorThread.java
@@ -12,6 +12,7 @@ import java.util.concurrent.locks.LockSupport;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerJoinEvent;
 

--- a/orebfuscator-plugin/src/main/java/net/imprex/orebfuscator/proximity/ProximityDirectorThread.java
+++ b/orebfuscator-plugin/src/main/java/net/imprex/orebfuscator/proximity/ProximityDirectorThread.java
@@ -12,7 +12,6 @@ import java.util.concurrent.locks.LockSupport;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
-import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerJoinEvent;
 


### PR DESCRIPTION
## Description
Event priorities have been changed to MONITOR, and ignoring canceled events is also enabled for compatibility with other plugins that change events with a lower priority.

## Related Issue
closes #321 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
#321 

## How Has This Been Tested?
Not tested, since I can't build the jar at the moment, but it should work fine, since there are no major changes in the code.

## Types of Changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
