### PR TITLE
[#328] Fix NPE when using ProtocolLib 5.1.0 or older

### DIFF
--- a/orebfuscator-plugin/src/main/java/net/imprex/orebfuscator/obfuscation/ObfuscationListener.java
+++ b/orebfuscator-plugin/src/main/java/net/imprex/orebfuscator/obfuscation/ObfuscationListener.java
@@ -1,5 +1,6 @@
 package net.imprex.orebfuscator.obfuscation;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
@@ -27,7 +28,7 @@ import net.imprex.orebfuscator.util.PermissionUtil;
 
 public abstract class ObfuscationListener extends PacketAdapter {
 
-	private static final List<PacketType> PACKET_TYPES = List.of(
+	private static final List<PacketType> PACKET_TYPES = Arrays.asList(
 		PacketType.Play.Server.MAP_CHUNK,
 		PacketType.Play.Server.UNLOAD_CHUNK,
 		PacketType.Play.Server.LIGHT_UPDATE,


### PR DESCRIPTION
## Description
Fix NPE when using ProtocolLib 5.1.0 or older

## Related Issue
closes #328

## How Has This Been Tested?
Successfully tested with ProtocolLib 5.1.0 and latest dev build

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
