### PR TITLE
Improve overall memory footprint per player

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,20 +11,20 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         fetch-depth: 0
     - name: Set BUILD_VERSION
       run: echo "BUILD_VERSION=$(git describe --tags $(git rev-list --tags --max-count=1))-b$GITHUB_RUN_NUMBER" >> $GITHUB_ENV
     - name: Maven cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ~/.m2/repository
         key: ${{ runner.os }}-maven-${{ secrets.CACHE_VERSION }}-${{ hashFiles('./.github/workflows/buildtools.sh') }}
         restore-keys: |
           ${{ runner.os }}-maven-${{ secrets.CACHE_VERSION }}-
     - name: Set up JDK 8/17
-      uses: actions/setup-java@v3
+      uses: actions/setup-java@v4
       with:
         distribution: 'temurin'
         java-version: |
@@ -38,7 +38,7 @@ jobs:
         mvn clean package --batch-mode -Drevision=$BUILD_VERSION
         mv orebfuscator-plugin/target/orebfuscator-*.jar ./
     - name: Upload artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: orebfuscator-plugin
         path: ./orebfuscator-*.jar

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,20 +11,20 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         fetch-depth: 0
     - name: Set RELEASE_VERSION
       run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
     - name: Maven cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ~/.m2/repository
         key: ${{ runner.os }}-maven-${{ secrets.CACHE_VERSION }}-${{ hashFiles('./.github/workflows/buildtools.sh') }}
         restore-keys: |
           ${{ runner.os }}-maven-${{ secrets.CACHE_VERSION }}-
     - name: Set up JDK 8/17
-      uses: actions/setup-java@v3
+      uses: actions/setup-java@v4
       with:
         distribution: 'temurin'
         java-version: |

--- a/orebfuscator-common/src/main/java/net/imprex/orebfuscator/util/BlockPos.java
+++ b/orebfuscator-common/src/main/java/net/imprex/orebfuscator/util/BlockPos.java
@@ -58,6 +58,17 @@ public class BlockPos implements Comparable<BlockPos> {
 		return new BlockPos(x, y, z);
 	}
 
+	public int toSectionPos() {
+		return (this.x & 0xF) << 12 | (this.y & 0xFFF) << 0 | (this.z & 0xF) << 16;
+	}
+
+	public static BlockPos fromSectionPos(int x, int z, int sectionPos) {
+		x    += (sectionPos >> 12) & 0xF;
+		int y = (sectionPos << 20 >> 20);
+		z    += (sectionPos >> 16) & 0xF;
+		return new BlockPos(x, y, z);
+	}
+
 	@Override
 	public int compareTo(BlockPos other) {
 		if (this.y == other.y) {

--- a/orebfuscator-common/src/main/java/net/imprex/orebfuscator/util/BlockStateProperties.java
+++ b/orebfuscator-common/src/main/java/net/imprex/orebfuscator/util/BlockStateProperties.java
@@ -11,12 +11,14 @@ public class BlockStateProperties {
 	private final boolean isAir;
 	private final boolean isOccluding;
 	private final boolean isBlockEntity;
+	private final boolean isDefaultState;
 
 	private BlockStateProperties(Builder builder) {
 		this.id = builder.id;
 		this.isAir = builder.isAir;
 		this.isOccluding = builder.isOccluding;
 		this.isBlockEntity = builder.isBlockEntity;
+		this.isDefaultState = builder.isDefaultState;
 	}
 
 	public int getId() {
@@ -33,6 +35,10 @@ public class BlockStateProperties {
 
 	public boolean isBlockEntity() {
 		return isBlockEntity;
+	}
+
+	public boolean isDefaultState() {
+		return isDefaultState;
 	}
 
 	@Override
@@ -54,8 +60,8 @@ public class BlockStateProperties {
 
 	@Override
 	public String toString() {
-		return "BlockStateProperties [id=" + id + ", isAir=" + isAir + ", isOccluding=" + isOccluding
-				+ ", isBlockEntity=" + isBlockEntity + "]";
+		return "BlockStateProperties [id=" + id + ", isDefaultState=" + isDefaultState + ", isAir=" + isAir
+				+ ", isOccluding=" + isOccluding + ", isBlockEntity=" + isBlockEntity + "]";
 	}
 
 	public static class Builder {
@@ -65,6 +71,7 @@ public class BlockStateProperties {
 		private boolean isAir;
 		private boolean isOccluding;
 		private boolean isBlockEntity;
+		private boolean isDefaultState;
 
 		private Builder(int id) {
 			this.id = id;
@@ -82,6 +89,11 @@ public class BlockStateProperties {
 
 		public Builder withIsBlockEntity(boolean isBlockEntity) {
 			this.isBlockEntity = isBlockEntity;
+			return this;
+		}
+
+		public Builder withIsDefaultState(boolean isDefaultState) {
+			this.isDefaultState = isDefaultState;
 			return this;
 		}
 

--- a/orebfuscator-common/src/test/java/net/imprex/orebfuscator/util/BlockPosTest.java
+++ b/orebfuscator-common/src/test/java/net/imprex/orebfuscator/util/BlockPosTest.java
@@ -1,0 +1,44 @@
+package net.imprex.orebfuscator.util;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+public class BlockPosTest {
+
+	@Test
+	public void testLongFormat() {
+		BlockPos positionA = new BlockPos(-52134, BlockPos.MAX_Y, 6243234);
+		BlockPos positionB = new BlockPos(0, BlockPos.MIN_Y, -4);
+		BlockPos positionC = new BlockPos(15, 0, -5663423);
+		BlockPos positionD = new BlockPos(21523, 16, -5663423);
+
+		long valueA = positionA.toLong();
+		long valueB = positionB.toLong();
+		long valueC = positionC.toLong();
+		long valueD = positionD.toLong();
+
+		assertEquals(positionA, BlockPos.fromLong(valueA));
+		assertEquals(positionB, BlockPos.fromLong(valueB));
+		assertEquals(positionC, BlockPos.fromLong(valueC));
+		assertEquals(positionD, BlockPos.fromLong(valueD));
+	}
+
+	@Test
+	public void testSectionPos() {
+		final int chunkX = -42 << 4;
+		final int chunkZ = 6521 << 4;
+
+		BlockPos positionA = new BlockPos(chunkX + 8, BlockPos.MAX_Y, chunkZ);
+		BlockPos positionB = new BlockPos(chunkX, BlockPos.MIN_Y, chunkZ + 15);
+		BlockPos positionC = new BlockPos(chunkX + 15, 0, chunkZ + 4);
+
+		int sectionPosA = positionA.toSectionPos();
+		int sectionPosB = positionB.toSectionPos();
+		int sectionPosC = positionC.toSectionPos();
+
+		assertEquals(positionA, BlockPos.fromSectionPos(chunkX, chunkZ, sectionPosA));
+		assertEquals(positionB, BlockPos.fromSectionPos(chunkX, chunkZ, sectionPosB));
+		assertEquals(positionC, BlockPos.fromSectionPos(chunkX, chunkZ, sectionPosC));
+	}
+}

--- a/orebfuscator-nms/orebfuscator-nms-api/src/main/java/net/imprex/orebfuscator/nms/AbstractNmsManager.java
+++ b/orebfuscator-nms/orebfuscator-nms-api/src/main/java/net/imprex/orebfuscator/nms/AbstractNmsManager.java
@@ -27,16 +27,12 @@ public abstract class AbstractNmsManager implements NmsManager {
 		this.blockStates = new BlockStateProperties[uniqueBlockStateCount];
 	}
 
-	protected final void registerBlockStateProperties(BlockStateProperties properties) {
-		this.blockStates[properties.getId()] = properties;
-	}
+	protected final void registerBlockProperties(BlockProperties block) {
+		this.blocks.put(block.getKey(), block);
 
-	protected final void registerBlockProperties(BlockProperties properties) {
-		this.blocks.put(properties.getKey(), properties);
-	}
-
-	protected final BlockStateProperties getBlockStateProperties(int id) {
-		return this.blockStates[id];
+		for (BlockStateProperties blockState : block.getBlockStates()) {
+			this.blockStates[blockState.getId()] = blockState;
+		}
 	}
 
 	@Override

--- a/orebfuscator-nms/orebfuscator-nms-v1_10_R1/src/main/java/net/imprex/orebfuscator/nms/v1_10_R1/NmsManager.java
+++ b/orebfuscator-nms/orebfuscator-nms-v1_10_R1/src/main/java/net/imprex/orebfuscator/nms/v1_10_R1/NmsManager.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 import org.bukkit.World;
 import org.bukkit.craftbukkit.v1_10_R1.CraftWorld;
@@ -82,33 +83,25 @@ public class NmsManager extends AbstractNmsManager {
 			Block block = Block.REGISTRY.get(key);
 
 			ImmutableList<IBlockData> possibleBlockStates = block.t().a();
-			List<BlockStateProperties> possibleBlockStateProperties = new ArrayList<>();
+			BlockProperties.Builder builder = BlockProperties.builder(namespacedKey);
 
 			for (IBlockData blockState : possibleBlockStates) {
 	
 				BlockStateProperties properties = BlockStateProperties.builder(getBlockId(blockState))
 						.withIsAir(block instanceof BlockAir)
 						/**
-						* p -> for barrier/slime_block/spawner
-						* j -> for every other block
-						*/
+						 * p -> for barrier/slime_block/spawner
+						 * j -> for every other block
+						 */
 						.withIsOccluding(blockState.p() && block.j()/*canOcclude*/)
 						.withIsBlockEntity(block.isTileEntity())
+						.withIsDefaultState(Objects.equals(block.getBlockData(), blockState))
 						.build();
 
-				possibleBlockStateProperties.add(properties);
-				this.registerBlockStateProperties(properties);
+				builder.withBlockState(properties);
 			}
 
-			int defaultBlockStateId = getBlockId(block.getBlockData());
-			BlockStateProperties defaultBlockState = getBlockStateProperties(defaultBlockStateId);
-
-			BlockProperties blockProperties = BlockProperties.builder(namespacedKey)
-				.withDefaultBlockState(defaultBlockState)
-				.withPossibleBlockStates(ImmutableList.copyOf(possibleBlockStateProperties))
-				.build();
-			
-			this.registerBlockProperties(blockProperties);
+			this.registerBlockProperties(builder.build());
 		}
 	}
 

--- a/orebfuscator-nms/orebfuscator-nms-v1_11_R1/src/main/java/net/imprex/orebfuscator/nms/v1_11_R1/NmsManager.java
+++ b/orebfuscator-nms/orebfuscator-nms-v1_11_R1/src/main/java/net/imprex/orebfuscator/nms/v1_11_R1/NmsManager.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 import org.bukkit.World;
 import org.bukkit.craftbukkit.v1_11_R1.CraftWorld;
@@ -82,7 +83,7 @@ public class NmsManager extends AbstractNmsManager {
 			Block block = Block.REGISTRY.get(key);
 
 			ImmutableList<IBlockData> possibleBlockStates = block.s().a();
-			List<BlockStateProperties> possibleBlockStateProperties = new ArrayList<>();
+			BlockProperties.Builder builder = BlockProperties.builder(namespacedKey);
 
 			for (IBlockData blockState : possibleBlockStates) {
 	
@@ -94,21 +95,13 @@ public class NmsManager extends AbstractNmsManager {
 						 */
 						.withIsOccluding(blockState.q() && blockState.s()/*canOcclude*/)
 						.withIsBlockEntity(block.isTileEntity())
+						.withIsDefaultState(Objects.equals(block.getBlockData(), blockState))
 						.build();
 
-				possibleBlockStateProperties.add(properties);
-				this.registerBlockStateProperties(properties);
+				builder.withBlockState(properties);
 			}
 
-			int defaultBlockStateId = getBlockId(block.getBlockData());
-			BlockStateProperties defaultBlockState = getBlockStateProperties(defaultBlockStateId);
-
-			BlockProperties blockProperties = BlockProperties.builder(namespacedKey)
-				.withDefaultBlockState(defaultBlockState)
-				.withPossibleBlockStates(ImmutableList.copyOf(possibleBlockStateProperties))
-				.build();
-			
-			this.registerBlockProperties(blockProperties);
+			this.registerBlockProperties(builder.build());
 		}
 	}
 

--- a/orebfuscator-nms/orebfuscator-nms-v1_12_R1/src/main/java/net/imprex/orebfuscator/nms/v1_12_R1/NmsManager.java
+++ b/orebfuscator-nms/orebfuscator-nms-v1_12_R1/src/main/java/net/imprex/orebfuscator/nms/v1_12_R1/NmsManager.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 import org.bukkit.World;
 import org.bukkit.craftbukkit.v1_12_R1.CraftWorld;
@@ -82,32 +83,25 @@ public class NmsManager extends AbstractNmsManager {
 			Block block = Block.REGISTRY.get(key);
 
 			ImmutableList<IBlockData> possibleBlockStates = block.s().a();
-			List<BlockStateProperties> possibleBlockStateProperties = new ArrayList<>();
+			BlockProperties.Builder builder = BlockProperties.builder(namespacedKey);
 
 			for (IBlockData blockState : possibleBlockStates) {
+
 				BlockStateProperties properties = BlockStateProperties.builder(getBlockId(blockState))
 						.withIsAir(block instanceof BlockAir)
 						/**
-						* p -> for barrier/slime_block/spawner
-						* r -> for every other block
-						*/
+						 * p -> for barrier/slime_block/spawner
+						 * r -> for every other block
+						 */
 						.withIsOccluding(blockState.p() && blockState.r()/*canOcclude*/)
 						.withIsBlockEntity(block.isTileEntity())
+						.withIsDefaultState(Objects.equals(block.getBlockData(), blockState))
 						.build();
 
-				possibleBlockStateProperties.add(properties);
-				this.registerBlockStateProperties(properties);
+				builder.withBlockState(properties);
 			}
 
-			int defaultBlockStateId = getBlockId(block.getBlockData());
-			BlockStateProperties defaultBlockState = getBlockStateProperties(defaultBlockStateId);
-
-			BlockProperties blockProperties = BlockProperties.builder(namespacedKey)
-				.withDefaultBlockState(defaultBlockState)
-				.withPossibleBlockStates(ImmutableList.copyOf(possibleBlockStateProperties))
-				.build();
-			
-			this.registerBlockProperties(blockProperties);
+			this.registerBlockProperties(builder.build());
 		}
 	}
 

--- a/orebfuscator-nms/orebfuscator-nms-v1_13_R1/src/main/java/net/imprex/orebfuscator/nms/v1_13_R1/NmsManager.java
+++ b/orebfuscator-nms/orebfuscator-nms-v1_13_R1/src/main/java/net/imprex/orebfuscator/nms/v1_13_R1/NmsManager.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 import org.bukkit.World;
 import org.bukkit.craftbukkit.v1_13_R1.CraftWorld;
@@ -72,7 +73,7 @@ public class NmsManager extends AbstractNmsManager {
 			Block block = Block.REGISTRY.get(key);
 
 			ImmutableList<IBlockData> possibleBlockStates = block.getStates().a();
-			List<BlockStateProperties> possibleBlockStateProperties = new ArrayList<>();
+			BlockProperties.Builder builder = BlockProperties.builder(namespacedKey);
 
 			for (IBlockData blockState : possibleBlockStates) {
 				BlockStateProperties properties = BlockStateProperties.builder(Block.getCombinedId(blockState))
@@ -83,21 +84,13 @@ public class NmsManager extends AbstractNmsManager {
 						*/
 						.withIsOccluding(blockState.p() && blockState.r()/*canOcclude*/)
 						.withIsBlockEntity(block.isTileEntity())
+						.withIsDefaultState(Objects.equals(block.getBlockData(), blockState))
 						.build();
 
-				possibleBlockStateProperties.add(properties);
-				this.registerBlockStateProperties(properties);
+				builder.withBlockState(properties);
 			}
 
-			int defaultBlockStateId = Block.getCombinedId(block.getBlockData());
-			BlockStateProperties defaultBlockState = getBlockStateProperties(defaultBlockStateId);
-
-			BlockProperties blockProperties = BlockProperties.builder(namespacedKey)
-				.withDefaultBlockState(defaultBlockState)
-				.withPossibleBlockStates(ImmutableList.copyOf(possibleBlockStateProperties))
-				.build();
-			
-			this.registerBlockProperties(blockProperties);
+			this.registerBlockProperties(builder.build());
 		}
 	}
 

--- a/orebfuscator-nms/orebfuscator-nms-v1_13_R2/src/main/java/net/imprex/orebfuscator/nms/v1_13_R2/NmsManager.java
+++ b/orebfuscator-nms/orebfuscator-nms-v1_13_R2/src/main/java/net/imprex/orebfuscator/nms/v1_13_R2/NmsManager.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 import org.bukkit.World;
 import org.bukkit.craftbukkit.v1_13_R2.CraftWorld;
@@ -73,7 +74,7 @@ public class NmsManager extends AbstractNmsManager {
 			Block block = IRegistry.BLOCK.get(key);
 
 			ImmutableList<IBlockData> possibleBlockStates = block.getStates().a();
-			List<BlockStateProperties> possibleBlockStateProperties = new ArrayList<>();
+			BlockProperties.Builder builder = BlockProperties.builder(namespacedKey);
 
 			for (IBlockData blockState : possibleBlockStates) {
 				BlockStateProperties properties = BlockStateProperties.builder(Block.getCombinedId(blockState))
@@ -84,21 +85,13 @@ public class NmsManager extends AbstractNmsManager {
 						*/
 						.withIsOccluding(blockState.p() && blockState.r()/*canOcclude*/)
 						.withIsBlockEntity(block.isTileEntity())
+						.withIsDefaultState(Objects.equals(block.getBlockData(), blockState))
 						.build();
 
-				possibleBlockStateProperties.add(properties);
-				this.registerBlockStateProperties(properties);
+				builder.withBlockState(properties);
 			}
 
-			int defaultBlockStateId = Block.getCombinedId(block.getBlockData());
-			BlockStateProperties defaultBlockState = getBlockStateProperties(defaultBlockStateId);
-
-			BlockProperties blockProperties = BlockProperties.builder(namespacedKey)
-				.withDefaultBlockState(defaultBlockState)
-				.withPossibleBlockStates(ImmutableList.copyOf(possibleBlockStateProperties))
-				.build();
-			
-			this.registerBlockProperties(blockProperties);
+			this.registerBlockProperties(builder.build());
 		}
 	}
 

--- a/orebfuscator-nms/orebfuscator-nms-v1_14_R1/src/main/java/net/imprex/orebfuscator/nms/v1_14_R1/NmsManager.java
+++ b/orebfuscator-nms/orebfuscator-nms-v1_14_R1/src/main/java/net/imprex/orebfuscator/nms/v1_14_R1/NmsManager.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 import org.bukkit.Material;
 import org.bukkit.World;
@@ -75,7 +76,7 @@ public class NmsManager extends AbstractNmsManager {
 			Block block = IRegistry.BLOCK.get(key);
 
 			ImmutableList<IBlockData> possibleBlockStates = block.getStates().a();
-			List<BlockStateProperties> possibleBlockStateProperties = new ArrayList<>();
+			BlockProperties.Builder builder = BlockProperties.builder(namespacedKey);
 
 			for (IBlockData blockState : possibleBlockStates) {
 				Material material = CraftBlockData.fromData(blockState).getMaterial();
@@ -88,21 +89,13 @@ public class NmsManager extends AbstractNmsManager {
 						*/
 						.withIsOccluding(material.isOccluding() && blockState.o()/*canOcclude*/)
 						.withIsBlockEntity(block.isTileEntity())
+						.withIsDefaultState(Objects.equals(block.getBlockData(), blockState))
 						.build();
 
-				possibleBlockStateProperties.add(properties);
-				this.registerBlockStateProperties(properties);
+				builder.withBlockState(properties);
 			}
 
-			int defaultBlockStateId = Block.getCombinedId(block.getBlockData());
-			BlockStateProperties defaultBlockState = getBlockStateProperties(defaultBlockStateId);
-
-			BlockProperties blockProperties = BlockProperties.builder(namespacedKey)
-				.withDefaultBlockState(defaultBlockState)
-				.withPossibleBlockStates(ImmutableList.copyOf(possibleBlockStateProperties))
-				.build();
-			
-			this.registerBlockProperties(blockProperties);
+			this.registerBlockProperties(builder.build());
 		}
 	}
 

--- a/orebfuscator-nms/orebfuscator-nms-v1_15_R1/src/main/java/net/imprex/orebfuscator/nms/v1_15_R1/NmsManager.java
+++ b/orebfuscator-nms/orebfuscator-nms-v1_15_R1/src/main/java/net/imprex/orebfuscator/nms/v1_15_R1/NmsManager.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 import org.bukkit.Material;
 import org.bukkit.World;
@@ -75,7 +76,7 @@ public class NmsManager extends AbstractNmsManager {
 			Block block = IRegistry.BLOCK.get(key);
 
 			ImmutableList<IBlockData> possibleBlockStates = block.getStates().a();
-			List<BlockStateProperties> possibleBlockStateProperties = new ArrayList<>();
+			BlockProperties.Builder builder = BlockProperties.builder(namespacedKey);
 
 			for (IBlockData blockState : possibleBlockStates) {
 				Material material = CraftBlockData.fromData(blockState).getMaterial();
@@ -88,21 +89,13 @@ public class NmsManager extends AbstractNmsManager {
 						*/
 						.withIsOccluding(material.isOccluding() && blockState.o()/*canOcclude*/)
 						.withIsBlockEntity(block.isTileEntity())
+						.withIsDefaultState(Objects.equals(block.getBlockData(), blockState))
 						.build();
 
-				possibleBlockStateProperties.add(properties);
-				this.registerBlockStateProperties(properties);
+				builder.withBlockState(properties);
 			}
 
-			int defaultBlockStateId = Block.getCombinedId(block.getBlockData());
-			BlockStateProperties defaultBlockState = getBlockStateProperties(defaultBlockStateId);
-
-			BlockProperties blockProperties = BlockProperties.builder(namespacedKey)
-				.withDefaultBlockState(defaultBlockState)
-				.withPossibleBlockStates(ImmutableList.copyOf(possibleBlockStateProperties))
-				.build();
-			
-			this.registerBlockProperties(blockProperties);
+			this.registerBlockProperties(builder.build());
 		}
 	}
 

--- a/orebfuscator-nms/orebfuscator-nms-v1_16_R1/src/main/java/net/imprex/orebfuscator/nms/v1_16_R1/NmsManager.java
+++ b/orebfuscator-nms/orebfuscator-nms-v1_16_R1/src/main/java/net/imprex/orebfuscator/nms/v1_16_R1/NmsManager.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 import org.bukkit.Material;
 import org.bukkit.World;
@@ -75,7 +76,7 @@ public class NmsManager extends AbstractNmsManager {
 			Block block = entry.getValue();
 
 			ImmutableList<IBlockData> possibleBlockStates = block.getStates().a();
-			List<BlockStateProperties> possibleBlockStateProperties = new ArrayList<>();
+			BlockProperties.Builder builder = BlockProperties.builder(namespacedKey);
 
 			for (IBlockData blockState : possibleBlockStates) {
 				Material material = CraftBlockData.fromData(blockState).getMaterial();
@@ -88,21 +89,13 @@ public class NmsManager extends AbstractNmsManager {
 						*/
 						.withIsOccluding(material.isOccluding() && blockState.l()/*canOcclude*/)
 						.withIsBlockEntity(block.isTileEntity())
+						.withIsDefaultState(Objects.equals(block.getBlockData(), blockState))
 						.build();
 
-				possibleBlockStateProperties.add(properties);
-				this.registerBlockStateProperties(properties);
+				builder.withBlockState(properties);
 			}
 
-			int defaultBlockStateId = Block.getCombinedId(block.getBlockData());
-			BlockStateProperties defaultBlockState = getBlockStateProperties(defaultBlockStateId);
-
-			BlockProperties blockProperties = BlockProperties.builder(namespacedKey)
-				.withDefaultBlockState(defaultBlockState)
-				.withPossibleBlockStates(ImmutableList.copyOf(possibleBlockStateProperties))
-				.build();
-			
-			this.registerBlockProperties(blockProperties);
+			this.registerBlockProperties(builder.build());
 		}
 	}
 

--- a/orebfuscator-nms/orebfuscator-nms-v1_16_R2/src/main/java/net/imprex/orebfuscator/nms/v1_16_R2/NmsManager.java
+++ b/orebfuscator-nms/orebfuscator-nms-v1_16_R2/src/main/java/net/imprex/orebfuscator/nms/v1_16_R2/NmsManager.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 
 import org.bukkit.Material;
@@ -75,7 +76,7 @@ public class NmsManager extends AbstractNmsManager {
 			Block block = entry.getValue();
 
 			ImmutableList<IBlockData> possibleBlockStates = block.getStates().a();
-			List<BlockStateProperties> possibleBlockStateProperties = new ArrayList<>();
+			BlockProperties.Builder builder = BlockProperties.builder(namespacedKey);
 
 			for (IBlockData blockState : possibleBlockStates) {
 				Material material = CraftBlockData.fromData(blockState).getMaterial();
@@ -88,21 +89,13 @@ public class NmsManager extends AbstractNmsManager {
 						*/
 						.withIsOccluding(material.isOccluding() && blockState.l()/*canOcclude*/)
 						.withIsBlockEntity(block.isTileEntity())
+						.withIsDefaultState(Objects.equals(block.getBlockData(), blockState))
 						.build();
 
-				possibleBlockStateProperties.add(properties);
-				this.registerBlockStateProperties(properties);
+				builder.withBlockState(properties);
 			}
 
-			int defaultBlockStateId = Block.getCombinedId(block.getBlockData());
-			BlockStateProperties defaultBlockState = getBlockStateProperties(defaultBlockStateId);
-
-			BlockProperties blockProperties = BlockProperties.builder(namespacedKey)
-				.withDefaultBlockState(defaultBlockState)
-				.withPossibleBlockStates(ImmutableList.copyOf(possibleBlockStateProperties))
-				.build();
-			
-			this.registerBlockProperties(blockProperties);
+			this.registerBlockProperties(builder.build());
 		}
 	}
 

--- a/orebfuscator-nms/orebfuscator-nms-v1_16_R3/src/main/java/net/imprex/orebfuscator/nms/v1_16_R3/NmsManager.java
+++ b/orebfuscator-nms/orebfuscator-nms-v1_16_R3/src/main/java/net/imprex/orebfuscator/nms/v1_16_R3/NmsManager.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 
 import org.bukkit.Material;
@@ -75,7 +76,7 @@ public class NmsManager extends AbstractNmsManager {
 			Block block = entry.getValue();
 
 			ImmutableList<IBlockData> possibleBlockStates = block.getStates().a();
-			List<BlockStateProperties> possibleBlockStateProperties = new ArrayList<>();
+			BlockProperties.Builder builder = BlockProperties.builder(namespacedKey);
 
 			for (IBlockData blockState : possibleBlockStates) {
 				Material material = CraftBlockData.fromData(blockState).getMaterial();
@@ -88,21 +89,13 @@ public class NmsManager extends AbstractNmsManager {
 						*/
 						.withIsOccluding(material.isOccluding() && blockState.l()/*canOcclude*/)
 						.withIsBlockEntity(block.isTileEntity())
+						.withIsDefaultState(Objects.equals(block.getBlockData(), blockState))
 						.build();
 
-				possibleBlockStateProperties.add(properties);
-				this.registerBlockStateProperties(properties);
+				builder.withBlockState(properties);
 			}
 
-			int defaultBlockStateId = Block.getCombinedId(block.getBlockData());
-			BlockStateProperties defaultBlockState = getBlockStateProperties(defaultBlockStateId);
-
-			BlockProperties blockProperties = BlockProperties.builder(namespacedKey)
-				.withDefaultBlockState(defaultBlockState)
-				.withPossibleBlockStates(ImmutableList.copyOf(possibleBlockStateProperties))
-				.build();
-			
-			this.registerBlockProperties(blockProperties);
+			this.registerBlockProperties(builder.build());
 		}
 	}
 

--- a/orebfuscator-nms/orebfuscator-nms-v1_17_R1/src/main/java/net/imprex/orebfuscator/nms/v1_17_R1/NmsManager.java
+++ b/orebfuscator-nms/orebfuscator-nms-v1_17_R1/src/main/java/net/imprex/orebfuscator/nms/v1_17_R1/NmsManager.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 
 import org.bukkit.Material;
@@ -74,7 +75,7 @@ public class NmsManager extends AbstractNmsManager {
 			Block block = entry.getValue();
 
 			ImmutableList<BlockState> possibleBlockStates = block.getStateDefinition().getPossibleStates();
-			List<BlockStateProperties> possibleBlockStateProperties = new ArrayList<>();
+			BlockProperties.Builder builder = BlockProperties.builder(namespacedKey);
 
 			for (BlockState blockState : possibleBlockStates) {
 				Material material = CraftBlockData.fromData(blockState).getMaterial();
@@ -84,21 +85,13 @@ public class NmsManager extends AbstractNmsManager {
 						// check if material is occluding and use blockData check for rare edge cases like barrier, spawner, slime_block, ...
 						.withIsOccluding(material.isOccluding() && blockState.canOcclude())
 						.withIsBlockEntity(blockState.hasBlockEntity())
+						.withIsDefaultState(Objects.equals(block.defaultBlockState(), blockState))
 						.build();
 
-				possibleBlockStateProperties.add(properties);
-				this.registerBlockStateProperties(properties);
+				builder.withBlockState(properties);
 			}
 
-			int defaultBlockStateId = Block.getId(block.defaultBlockState());
-			BlockStateProperties defaultBlockState = getBlockStateProperties(defaultBlockStateId);
-
-			BlockProperties blockProperties = BlockProperties.builder(namespacedKey)
-				.withDefaultBlockState(defaultBlockState)
-				.withPossibleBlockStates(ImmutableList.copyOf(possibleBlockStateProperties))
-				.build();
-			
-			this.registerBlockProperties(blockProperties);
+			this.registerBlockProperties(builder.build());
 		}
 	}
 

--- a/orebfuscator-nms/orebfuscator-nms-v1_18_R1/src/main/java/net/imprex/orebfuscator/nms/v1_18_R1/NmsManager.java
+++ b/orebfuscator-nms/orebfuscator-nms-v1_18_R1/src/main/java/net/imprex/orebfuscator/nms/v1_18_R1/NmsManager.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 import org.bukkit.Material;
 import org.bukkit.World;
@@ -75,7 +76,7 @@ public class NmsManager extends AbstractNmsManager {
 			Block block = entry.getValue();
 
 			ImmutableList<BlockState> possibleBlockStates = block.getStateDefinition().getPossibleStates();
-			List<BlockStateProperties> possibleBlockStateProperties = new ArrayList<>();
+			BlockProperties.Builder builder = BlockProperties.builder(namespacedKey);
 
 			for (BlockState blockState : possibleBlockStates) {
 				Material material = CraftBlockData.fromData(blockState).getMaterial();
@@ -85,21 +86,13 @@ public class NmsManager extends AbstractNmsManager {
 						// check if material is occluding and use blockData check for rare edge cases like barrier, spawner, slime_block, ...
 						.withIsOccluding(material.isOccluding() && blockState.canOcclude())
 						.withIsBlockEntity(blockState.hasBlockEntity())
+						.withIsDefaultState(Objects.equals(block.defaultBlockState(), blockState))
 						.build();
 
-				possibleBlockStateProperties.add(properties);
-				this.registerBlockStateProperties(properties);
+				builder.withBlockState(properties);
 			}
 
-			int defaultBlockStateId = Block.getId(block.defaultBlockState());
-			BlockStateProperties defaultBlockState = getBlockStateProperties(defaultBlockStateId);
-
-			BlockProperties blockProperties = BlockProperties.builder(namespacedKey)
-				.withDefaultBlockState(defaultBlockState)
-				.withPossibleBlockStates(ImmutableList.copyOf(possibleBlockStateProperties))
-				.build();
-			
-			this.registerBlockProperties(blockProperties);
+			this.registerBlockProperties(builder.build());
 		}
 	}
 

--- a/orebfuscator-nms/orebfuscator-nms-v1_18_R2/src/main/java/net/imprex/orebfuscator/nms/v1_18_R2/NmsManager.java
+++ b/orebfuscator-nms/orebfuscator-nms-v1_18_R2/src/main/java/net/imprex/orebfuscator/nms/v1_18_R2/NmsManager.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 import org.bukkit.Material;
 import org.bukkit.World;
@@ -75,7 +76,7 @@ public class NmsManager extends AbstractNmsManager {
 			Block block = entry.getValue();
 
 			ImmutableList<BlockState> possibleBlockStates = block.getStateDefinition().getPossibleStates();
-			List<BlockStateProperties> possibleBlockStateProperties = new ArrayList<>();
+			BlockProperties.Builder builder = BlockProperties.builder(namespacedKey);
 
 			for (BlockState blockState : possibleBlockStates) {
 				Material material = CraftBlockData.fromData(blockState).getMaterial();
@@ -85,21 +86,13 @@ public class NmsManager extends AbstractNmsManager {
 						// check if material is occluding and use blockData check for rare edge cases like barrier, spawner, slime_block, ...
 						.withIsOccluding(material.isOccluding() && blockState.canOcclude())
 						.withIsBlockEntity(blockState.hasBlockEntity())
+						.withIsDefaultState(Objects.equals(block.defaultBlockState(), blockState))
 						.build();
 
-				possibleBlockStateProperties.add(properties);
-				this.registerBlockStateProperties(properties);
+				builder.withBlockState(properties);
 			}
 
-			int defaultBlockStateId = Block.getId(block.defaultBlockState());
-			BlockStateProperties defaultBlockState = getBlockStateProperties(defaultBlockStateId);
-
-			BlockProperties blockProperties = BlockProperties.builder(namespacedKey)
-				.withDefaultBlockState(defaultBlockState)
-				.withPossibleBlockStates(ImmutableList.copyOf(possibleBlockStateProperties))
-				.build();
-			
-			this.registerBlockProperties(blockProperties);
+			this.registerBlockProperties(builder.build());
 		}
 	}
 

--- a/orebfuscator-nms/orebfuscator-nms-v1_19_R1/src/main/java/net/imprex/orebfuscator/nms/v1_19_R1/NmsManager.java
+++ b/orebfuscator-nms/orebfuscator-nms-v1_19_R1/src/main/java/net/imprex/orebfuscator/nms/v1_19_R1/NmsManager.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 import org.bukkit.Material;
 import org.bukkit.World;
@@ -74,7 +75,7 @@ public class NmsManager extends AbstractNmsManager {
 			Block block = entry.getValue();
 
 			ImmutableList<BlockState> possibleBlockStates = block.getStateDefinition().getPossibleStates();
-			List<BlockStateProperties> possibleBlockStateProperties = new ArrayList<>();
+			BlockProperties.Builder builder = BlockProperties.builder(namespacedKey);
 
 			for (BlockState blockState : possibleBlockStates) {
 				Material material = CraftBlockData.fromData(blockState).getMaterial();
@@ -84,21 +85,13 @@ public class NmsManager extends AbstractNmsManager {
 						// check if material is occluding and use blockData check for rare edge cases like barrier, spawner, slime_block, ...
 						.withIsOccluding(material.isOccluding() && blockState.canOcclude())
 						.withIsBlockEntity(blockState.hasBlockEntity())
+						.withIsDefaultState(Objects.equals(block.defaultBlockState(), blockState))
 						.build();
 
-				possibleBlockStateProperties.add(properties);
-				this.registerBlockStateProperties(properties);
+				builder.withBlockState(properties);
 			}
 
-			int defaultBlockStateId = Block.getId(block.defaultBlockState());
-			BlockStateProperties defaultBlockState = getBlockStateProperties(defaultBlockStateId);
-
-			BlockProperties blockProperties = BlockProperties.builder(namespacedKey)
-				.withDefaultBlockState(defaultBlockState)
-				.withPossibleBlockStates(ImmutableList.copyOf(possibleBlockStateProperties))
-				.build();
-			
-			this.registerBlockProperties(blockProperties);
+			this.registerBlockProperties(builder.build());
 		}
 	}
 

--- a/orebfuscator-nms/orebfuscator-nms-v1_19_R2/src/main/java/net/imprex/orebfuscator/nms/v1_19_R2/NmsManager.java
+++ b/orebfuscator-nms/orebfuscator-nms-v1_19_R2/src/main/java/net/imprex/orebfuscator/nms/v1_19_R2/NmsManager.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 import org.bukkit.Material;
 import org.bukkit.World;
@@ -74,7 +75,7 @@ public class NmsManager extends AbstractNmsManager {
 			Block block = entry.getValue();
 
 			ImmutableList<BlockState> possibleBlockStates = block.getStateDefinition().getPossibleStates();
-			List<BlockStateProperties> possibleBlockStateProperties = new ArrayList<>();
+			BlockProperties.Builder builder = BlockProperties.builder(namespacedKey);
 
 			for (BlockState blockState : possibleBlockStates) {
 				Material material = CraftBlockData.fromData(blockState).getMaterial();
@@ -84,21 +85,13 @@ public class NmsManager extends AbstractNmsManager {
 						// check if material is occluding and use blockData check for rare edge cases like barrier, spawner, slime_block, ...
 						.withIsOccluding(material.isOccluding() && blockState.canOcclude())
 						.withIsBlockEntity(blockState.hasBlockEntity())
+						.withIsDefaultState(Objects.equals(block.defaultBlockState(), blockState))
 						.build();
 
-				possibleBlockStateProperties.add(properties);
-				this.registerBlockStateProperties(properties);
+				builder.withBlockState(properties);
 			}
 
-			int defaultBlockStateId = Block.getId(block.defaultBlockState());
-			BlockStateProperties defaultBlockState = getBlockStateProperties(defaultBlockStateId);
-
-			BlockProperties blockProperties = BlockProperties.builder(namespacedKey)
-				.withDefaultBlockState(defaultBlockState)
-				.withPossibleBlockStates(ImmutableList.copyOf(possibleBlockStateProperties))
-				.build();
-			
-			this.registerBlockProperties(blockProperties);
+			this.registerBlockProperties(builder.build());
 		}
 	}
 

--- a/orebfuscator-nms/orebfuscator-nms-v1_19_R3/src/main/java/net/imprex/orebfuscator/nms/v1_19_R3/NmsManager.java
+++ b/orebfuscator-nms/orebfuscator-nms-v1_19_R3/src/main/java/net/imprex/orebfuscator/nms/v1_19_R3/NmsManager.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 import org.bukkit.Material;
 import org.bukkit.World;
@@ -74,7 +75,7 @@ public class NmsManager extends AbstractNmsManager {
 			Block block = entry.getValue();
 
 			ImmutableList<BlockState> possibleBlockStates = block.getStateDefinition().getPossibleStates();
-			List<BlockStateProperties> possibleBlockStateProperties = new ArrayList<>();
+			BlockProperties.Builder builder = BlockProperties.builder(namespacedKey);
 
 			for (BlockState blockState : possibleBlockStates) {
 				Material material = CraftBlockData.fromData(blockState).getMaterial();
@@ -84,21 +85,13 @@ public class NmsManager extends AbstractNmsManager {
 						// check if material is occluding and use blockData check for rare edge cases like barrier, spawner, slime_block, ...
 						.withIsOccluding(material.isOccluding() && blockState.canOcclude())
 						.withIsBlockEntity(blockState.hasBlockEntity())
+						.withIsDefaultState(Objects.equals(block.defaultBlockState(), blockState))
 						.build();
 
-				possibleBlockStateProperties.add(properties);
-				this.registerBlockStateProperties(properties);
+				builder.withBlockState(properties);
 			}
 
-			int defaultBlockStateId = Block.getId(block.defaultBlockState());
-			BlockStateProperties defaultBlockState = getBlockStateProperties(defaultBlockStateId);
-
-			BlockProperties blockProperties = BlockProperties.builder(namespacedKey)
-				.withDefaultBlockState(defaultBlockState)
-				.withPossibleBlockStates(ImmutableList.copyOf(possibleBlockStateProperties))
-				.build();
-			
-			this.registerBlockProperties(blockProperties);
+			this.registerBlockProperties(builder.build());
 		}
 	}
 

--- a/orebfuscator-nms/orebfuscator-nms-v1_20_R1/src/main/java/net/imprex/orebfuscator/nms/v1_20_R1/NmsManager.java
+++ b/orebfuscator-nms/orebfuscator-nms-v1_20_R1/src/main/java/net/imprex/orebfuscator/nms/v1_20_R1/NmsManager.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 import org.bukkit.Material;
 import org.bukkit.World;
@@ -74,7 +75,7 @@ public class NmsManager extends AbstractNmsManager {
 			Block block = entry.getValue();
 
 			ImmutableList<BlockState> possibleBlockStates = block.getStateDefinition().getPossibleStates();
-			List<BlockStateProperties> possibleBlockStateProperties = new ArrayList<>();
+			BlockProperties.Builder builder = BlockProperties.builder(namespacedKey);
 
 			for (BlockState blockState : possibleBlockStates) {
 				Material material = CraftBlockData.fromData(blockState).getMaterial();
@@ -84,21 +85,13 @@ public class NmsManager extends AbstractNmsManager {
 						// check if material is occluding and use blockData check for rare edge cases like barrier, spawner, slime_block, ...
 						.withIsOccluding(material.isOccluding() && blockState.canOcclude())
 						.withIsBlockEntity(blockState.hasBlockEntity())
+						.withIsDefaultState(Objects.equals(block.defaultBlockState(), blockState))
 						.build();
 
-				possibleBlockStateProperties.add(properties);
-				this.registerBlockStateProperties(properties);
+				builder.withBlockState(properties);
 			}
 
-			int defaultBlockStateId = Block.getId(block.defaultBlockState());
-			BlockStateProperties defaultBlockState = getBlockStateProperties(defaultBlockStateId);
-
-			BlockProperties blockProperties = BlockProperties.builder(namespacedKey)
-				.withDefaultBlockState(defaultBlockState)
-				.withPossibleBlockStates(ImmutableList.copyOf(possibleBlockStateProperties))
-				.build();
-			
-			this.registerBlockProperties(blockProperties);
+			this.registerBlockProperties(builder.build());
 		}
 	}
 

--- a/orebfuscator-nms/orebfuscator-nms-v1_20_R2/src/main/java/net/imprex/orebfuscator/nms/v1_20_R2/NmsManager.java
+++ b/orebfuscator-nms/orebfuscator-nms-v1_20_R2/src/main/java/net/imprex/orebfuscator/nms/v1_20_R2/NmsManager.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 import org.bukkit.Material;
 import org.bukkit.World;
@@ -74,7 +75,7 @@ public class NmsManager extends AbstractNmsManager {
 			Block block = entry.getValue();
 
 			ImmutableList<BlockState> possibleBlockStates = block.getStateDefinition().getPossibleStates();
-			List<BlockStateProperties> possibleBlockStateProperties = new ArrayList<>();
+			BlockProperties.Builder builder = BlockProperties.builder(namespacedKey);
 
 			for (BlockState blockState : possibleBlockStates) {
 				Material material = CraftBlockData.fromData(blockState).getMaterial();
@@ -84,21 +85,13 @@ public class NmsManager extends AbstractNmsManager {
 						// check if material is occluding and use blockData check for rare edge cases like barrier, spawner, slime_block, ...
 						.withIsOccluding(material.isOccluding() && blockState.canOcclude())
 						.withIsBlockEntity(blockState.hasBlockEntity())
+						.withIsDefaultState(Objects.equals(block.defaultBlockState(), blockState))
 						.build();
 
-				possibleBlockStateProperties.add(properties);
-				this.registerBlockStateProperties(properties);
+				builder.withBlockState(properties);
 			}
 
-			int defaultBlockStateId = Block.getId(block.defaultBlockState());
-			BlockStateProperties defaultBlockState = getBlockStateProperties(defaultBlockStateId);
-
-			BlockProperties blockProperties = BlockProperties.builder(namespacedKey)
-				.withDefaultBlockState(defaultBlockState)
-				.withPossibleBlockStates(ImmutableList.copyOf(possibleBlockStateProperties))
-				.build();
-			
-			this.registerBlockProperties(blockProperties);
+			this.registerBlockProperties(builder.build());
 		}
 	}
 

--- a/orebfuscator-nms/orebfuscator-nms-v1_20_R3/src/main/java/net/imprex/orebfuscator/nms/v1_20_R3/NmsManager.java
+++ b/orebfuscator-nms/orebfuscator-nms-v1_20_R3/src/main/java/net/imprex/orebfuscator/nms/v1_20_R3/NmsManager.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 import org.bukkit.Material;
 import org.bukkit.World;
@@ -74,7 +75,7 @@ public class NmsManager extends AbstractNmsManager {
 			Block block = entry.getValue();
 
 			ImmutableList<BlockState> possibleBlockStates = block.getStateDefinition().getPossibleStates();
-			List<BlockStateProperties> possibleBlockStateProperties = new ArrayList<>();
+			BlockProperties.Builder builder = BlockProperties.builder(namespacedKey);
 
 			for (BlockState blockState : possibleBlockStates) {
 				Material material = CraftBlockData.fromData(blockState).getMaterial();
@@ -84,21 +85,13 @@ public class NmsManager extends AbstractNmsManager {
 						// check if material is occluding and use blockData check for rare edge cases like barrier, spawner, slime_block, ...
 						.withIsOccluding(material.isOccluding() && blockState.canOcclude())
 						.withIsBlockEntity(blockState.hasBlockEntity())
+						.withIsDefaultState(Objects.equals(block.defaultBlockState(), blockState))
 						.build();
 
-				possibleBlockStateProperties.add(properties);
-				this.registerBlockStateProperties(properties);
+				builder.withBlockState(properties);
 			}
 
-			int defaultBlockStateId = Block.getId(block.defaultBlockState());
-			BlockStateProperties defaultBlockState = getBlockStateProperties(defaultBlockStateId);
-
-			BlockProperties blockProperties = BlockProperties.builder(namespacedKey)
-				.withDefaultBlockState(defaultBlockState)
-				.withPossibleBlockStates(ImmutableList.copyOf(possibleBlockStateProperties))
-				.build();
-			
-			this.registerBlockProperties(blockProperties);
+			this.registerBlockProperties(builder.build());
 		}
 	}
 

--- a/orebfuscator-nms/orebfuscator-nms-v1_9_R2/src/main/java/net/imprex/orebfuscator/nms/v1_9_R2/NmsManager.java
+++ b/orebfuscator-nms/orebfuscator-nms-v1_9_R2/src/main/java/net/imprex/orebfuscator/nms/v1_9_R2/NmsManager.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 import org.bukkit.Material;
 import org.bukkit.World;
@@ -86,7 +87,7 @@ public class NmsManager extends AbstractNmsManager {
 			Material material = CraftMagicNumbers.getMaterial(block);
 
 			ImmutableList<IBlockData> possibleBlockStates = block.t().a();
-			List<BlockStateProperties> possibleBlockStateProperties = new ArrayList<>();
+			BlockProperties.Builder builder = BlockProperties.builder(namespacedKey);
 
 			for (IBlockData blockState : possibleBlockStates) {
 	
@@ -94,21 +95,13 @@ public class NmsManager extends AbstractNmsManager {
 						.withIsAir(block instanceof BlockAir)
 						.withIsOccluding(material.isOccluding())
 						.withIsBlockEntity(block.isTileEntity())
+						.withIsDefaultState(Objects.equals(block.getBlockData(), blockState))
 						.build();
 
-				possibleBlockStateProperties.add(properties);
-				this.registerBlockStateProperties(properties);
+				builder.withBlockState(properties);
 			}
 
-			int defaultBlockStateId = getBlockId(block.getBlockData());
-			BlockStateProperties defaultBlockState = getBlockStateProperties(defaultBlockStateId);
-
-			BlockProperties blockProperties = BlockProperties.builder(namespacedKey)
-				.withDefaultBlockState(defaultBlockState)
-				.withPossibleBlockStates(ImmutableList.copyOf(possibleBlockStateProperties))
-				.build();
-			
-			this.registerBlockProperties(blockProperties);
+			this.registerBlockProperties(builder.build());
 		}
 	}
 

--- a/orebfuscator-plugin/src/main/java/net/imprex/orebfuscator/config/OrebfuscatorBlockFlags.java
+++ b/orebfuscator-plugin/src/main/java/net/imprex/orebfuscator/config/OrebfuscatorBlockFlags.java
@@ -37,7 +37,7 @@ public class OrebfuscatorBlockFlags implements BlockFlags {
 	}
 
 	private void setBlockBits(BlockProperties block, int bits) {
-		for (BlockStateProperties blockState : block.getPossibleBlockStates()) {
+		for (BlockStateProperties blockState : block.getBlockStates()) {
 			int blockMask = this.blockFlags[blockState.getId()] | bits;
 
 			if (blockState.isBlockEntity()) {

--- a/orebfuscator-plugin/src/main/java/net/imprex/orebfuscator/obfuscation/ObfuscationProcessor.java
+++ b/orebfuscator-plugin/src/main/java/net/imprex/orebfuscator/obfuscation/ObfuscationProcessor.java
@@ -1,6 +1,8 @@
 package net.imprex.orebfuscator.obfuscation;
 
+import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 import org.bukkit.World;
@@ -39,7 +41,7 @@ public class ObfuscationProcessor {
 		ProximityConfig proximityConfig = bundle.proximity();
 
 		Set<BlockPos> blockEntities = new HashSet<>();
-		Set<BlockPos> proximityBlocks = new HashSet<>();
+		List<BlockPos> proximityBlocks = new ArrayList<>();
 
 		int baseX = chunkStruct.chunkX << 4;
 		int baseZ = chunkStruct.chunkZ << 4;

--- a/orebfuscator-plugin/src/main/java/net/imprex/orebfuscator/obfuscation/ObfuscationRequest.java
+++ b/orebfuscator-plugin/src/main/java/net/imprex/orebfuscator/obfuscation/ObfuscationRequest.java
@@ -1,6 +1,7 @@
 package net.imprex.orebfuscator.obfuscation;
 
 import java.util.Arrays;
+import java.util.List;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 
@@ -64,7 +65,7 @@ public class ObfuscationRequest {
 		return this.future;
 	}
 
-	public ObfuscationResult createResult(byte[] data, Set<BlockPos> blockEntities, Set<BlockPos> proximityBlocks) {
+	public ObfuscationResult createResult(byte[] data, Set<BlockPos> blockEntities, List<BlockPos> proximityBlocks) {
 		return new ObfuscationResult(this.position, this.chunkHash, data, blockEntities, proximityBlocks);
 	}
 

--- a/orebfuscator-plugin/src/main/java/net/imprex/orebfuscator/obfuscation/ObfuscationResult.java
+++ b/orebfuscator-plugin/src/main/java/net/imprex/orebfuscator/obfuscation/ObfuscationResult.java
@@ -1,6 +1,8 @@
 package net.imprex.orebfuscator.obfuscation;
 
+import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 import net.imprex.orebfuscator.util.BlockPos;
@@ -14,14 +16,14 @@ public class ObfuscationResult {
 	private final byte[] data;
 
 	private final Set<BlockPos> blockEntities;
-	private final Set<BlockPos> proximityBlocks;
+	private final List<BlockPos> proximityBlocks;
 
 	public ObfuscationResult(ChunkPosition position, byte[] hash, byte[] data) {
-		this(position, hash, data, new HashSet<>(), new HashSet<>());
+		this(position, hash, data, new HashSet<>(), new ArrayList<>());
 	}
 
 	public ObfuscationResult(ChunkPosition position, byte[] hash, byte[] data,
-			Set<BlockPos> blockEntities, Set<BlockPos> proximityBlocks) {
+			Set<BlockPos> blockEntities, List<BlockPos> proximityBlocks) {
 		this.position = position;
 		this.hash = hash;
 		this.data = data;
@@ -45,7 +47,7 @@ public class ObfuscationResult {
 		return blockEntities;
 	}
 
-	public Set<BlockPos> getProximityBlocks() {
+	public List<BlockPos> getProximityBlocks() {
 		return proximityBlocks;
 	}
 }

--- a/orebfuscator-plugin/src/main/java/net/imprex/orebfuscator/obfuscation/ObfuscationTask.java
+++ b/orebfuscator-plugin/src/main/java/net/imprex/orebfuscator/obfuscation/ObfuscationTask.java
@@ -1,5 +1,6 @@
 package net.imprex.orebfuscator.obfuscation;
 
+import java.util.List;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 
@@ -38,7 +39,7 @@ public class ObfuscationTask {
 		return this.request.getChunkStruct();
 	}
 
-	public void complete(byte[] data, Set<BlockPos> blockEntities, Set<BlockPos> proximityBlocks) {
+	public void complete(byte[] data, Set<BlockPos> blockEntities, List<BlockPos> proximityBlocks) {
 		this.request.complete(this.request.createResult(data, blockEntities, proximityBlocks));
 	}
 

--- a/orebfuscator-plugin/src/main/java/net/imprex/orebfuscator/player/OrebfuscatorPlayer.java
+++ b/orebfuscator-plugin/src/main/java/net/imprex/orebfuscator/player/OrebfuscatorPlayer.java
@@ -1,8 +1,7 @@
 package net.imprex.orebfuscator.player;
 
-import java.util.Collections;
+import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -23,7 +22,7 @@ public class OrebfuscatorPlayer {
 	private final AdvancedConfig config;
 
 	private final AtomicReference<World> world = new AtomicReference<>();
-	private final Map<Long, Set<BlockPos>> chunks = new ConcurrentHashMap<>();
+	private final Map<Long, OrebfuscatorPlayerChunk> chunks = new ConcurrentHashMap<>();
 
 	private volatile long latestUpdateTimestamp = System.currentTimeMillis();
 	private volatile Location location = new Location(null, 0, 0, 0);
@@ -112,20 +111,16 @@ public class OrebfuscatorPlayer {
 		}
 	}
 
-	public void addChunk(int chunkX, int chunkZ, Set<BlockPos> blocks) {
-		long key = ChunkPosition.toLong(chunkX, chunkZ);
-		this.chunks.computeIfAbsent(key, k -> {
-			return Collections.newSetFromMap(new ConcurrentHashMap<>());
-		}).addAll(blocks);
+	public void addChunk(int chunkX, int chunkZ, List<BlockPos> blocks) {
+		this.chunks.put(ChunkPosition.toLong(chunkX, chunkZ),
+				new OrebfuscatorPlayerChunk(chunkX, chunkZ, blocks));
 	}
 
-	public Set<BlockPos> getChunk(int chunkX, int chunkZ) {
-		long key = ChunkPosition.toLong(chunkX, chunkZ);
-		return this.chunks.getOrDefault(key, Collections.emptySet());
+	public OrebfuscatorPlayerChunk getChunk(int chunkX, int chunkZ) {
+		return this.chunks.get(ChunkPosition.toLong(chunkX, chunkZ));
 	}
 
 	public void removeChunk(int chunkX, int chunkZ) {
-		long key = ChunkPosition.toLong(chunkX, chunkZ);
-		this.chunks.remove(key);
+		this.chunks.remove(ChunkPosition.toLong(chunkX, chunkZ));
 	}
 }

--- a/orebfuscator-plugin/src/main/java/net/imprex/orebfuscator/player/OrebfuscatorPlayerChunk.java
+++ b/orebfuscator-plugin/src/main/java/net/imprex/orebfuscator/player/OrebfuscatorPlayerChunk.java
@@ -1,0 +1,78 @@
+package net.imprex.orebfuscator.player;
+
+import java.util.Iterator;
+import java.util.List;
+import java.util.NoSuchElementException;
+
+import net.imprex.orebfuscator.util.BlockPos;
+
+public class OrebfuscatorPlayerChunk {
+
+	private final int chunkX;
+	private final int chunkZ;
+
+	private int proximitySize;
+	private final int[] proximityBlocks;
+
+	public OrebfuscatorPlayerChunk(int chunkX, int chunkZ, List<BlockPos> proximityBlocks) {
+		this.chunkX = chunkX;
+		this.chunkZ = chunkZ;
+
+		this.proximitySize = proximityBlocks.size();
+		this.proximityBlocks = new int[proximityBlocks.size()];
+
+		for (int i = 0; i < proximityBlocks.size(); i++) {
+			this.proximityBlocks[i] = proximityBlocks.get(i).toSectionPos();
+		}
+	}
+
+	public boolean isEmpty() {
+		return proximitySize <= 0;
+	}
+
+	public Iterator<BlockPos> proximityIterator() {
+		return new ProximityItr();
+	}
+
+	private class ProximityItr implements Iterator<BlockPos> {
+
+		private final int x = chunkX << 4;
+		private final int z = chunkZ << 4;
+
+		private int cursor;
+		private int returnCursor = -1;
+
+		@Override
+		public boolean hasNext() {
+			return cursor < proximitySize;
+		}
+
+		@Override
+		public BlockPos next() {
+			if (cursor >= proximitySize)
+				throw new NoSuchElementException();
+
+			int sectionPos = proximityBlocks[returnCursor = cursor];
+			cursor++;
+
+			return BlockPos.fromSectionPos(x, z, sectionPos);
+		}
+
+		@Override
+		public void remove() {
+			if (returnCursor < 0)
+                throw new IllegalStateException();
+
+			// remove entry
+			final int index = returnCursor;
+			final int newSize;
+			if ((newSize = proximitySize - 1) > index)
+				System.arraycopy(proximityBlocks, index + 1, proximityBlocks, index, newSize - index);
+			proximityBlocks[proximitySize = newSize] = 0xFFFFFFFF;
+
+			// update cursor positions
+			cursor = returnCursor;
+			returnCursor = -1;
+		}
+	}
+}

--- a/orebfuscator-plugin/src/main/java/net/imprex/orebfuscator/player/OrebfuscatorPlayerMap.java
+++ b/orebfuscator-plugin/src/main/java/net/imprex/orebfuscator/player/OrebfuscatorPlayerMap.java
@@ -7,7 +7,7 @@ import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
-import org.bukkit.event.player.PlayerLoginEvent;
+import org.bukkit.event.player.PlayerJoinEvent;
 import org.bukkit.event.player.PlayerQuitEvent;
 
 import net.imprex.orebfuscator.Orebfuscator;
@@ -34,7 +34,7 @@ public class OrebfuscatorPlayerMap implements Listener {
 	}
 
 	@EventHandler
-	public void onLogin(PlayerLoginEvent event) {
+	public void onJoin(PlayerJoinEvent event) {
 		this.addPlayer(event.getPlayer());
 	}
 

--- a/orebfuscator-plugin/src/main/java/net/imprex/orebfuscator/proximity/ProximityWorker.java
+++ b/orebfuscator-plugin/src/main/java/net/imprex/orebfuscator/proximity/ProximityWorker.java
@@ -3,7 +3,6 @@ package net.imprex.orebfuscator.proximity;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Set;
 
 import org.bukkit.GameMode;
 import org.bukkit.Location;
@@ -18,6 +17,7 @@ import net.imprex.orebfuscator.OrebfuscatorNms;
 import net.imprex.orebfuscator.config.OrebfuscatorConfig;
 import net.imprex.orebfuscator.config.ProximityConfig;
 import net.imprex.orebfuscator.player.OrebfuscatorPlayer;
+import net.imprex.orebfuscator.player.OrebfuscatorPlayerChunk;
 import net.imprex.orebfuscator.player.OrebfuscatorPlayerMap;
 import net.imprex.orebfuscator.util.BlockPos;
 import net.imprex.orebfuscator.util.FastGazeUtil;
@@ -103,12 +103,12 @@ public class ProximityWorker {
 		for (int chunkZ = minChunkZ; chunkZ <= maxChunkZ; chunkZ++) {
 			for (int chunkX = minChunkX; chunkX <= maxChunkX; chunkX++) {
 
-				Set<BlockPos> blocks = orebfuscatorPlayer.getChunk(chunkX, chunkZ);
-				if (blocks == null) {
+				OrebfuscatorPlayerChunk chunk = orebfuscatorPlayer.getChunk(chunkX, chunkZ);
+				if (chunk == null) {
 					continue;
 				}
 
-				for (Iterator<BlockPos> iterator = blocks.iterator(); iterator.hasNext(); ) {
+				for (Iterator<BlockPos> iterator = chunk.proximityIterator(); iterator.hasNext(); ) {
 					BlockPos blockPos = iterator.next();
 
 					// check if block is in range
@@ -141,7 +141,7 @@ public class ProximityWorker {
 					updateBlocks.add(blockPos);
 				}
 
-				if (blocks.isEmpty()) {
+				if (chunk.isEmpty()) {
 					orebfuscatorPlayer.removeChunk(chunkX, chunkZ);
 				}
 			}


### PR DESCRIPTION
## Description
Fix a potential memory leak (low impact) that occurred when a players login process was cancelled (e.g. player is banned). Reduce memory usage per proximity block per player by theoretically up to x10.

## How Has This Been Tested?
Successfully tested with the latest spigot, paper and folia release.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
