### PR TITLE
Add "onlyCheckCenter" option to ray cast check

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ExternalStorageConfigurationManager" enabled="true" />
+  <component name="ProjectRootManager" version="2" default="true" />
+</project>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="ExternalStorageConfigurationManager" enabled="true" />
-  <component name="ProjectRootManager" version="2" default="true" />
-</project>

--- a/orebfuscator-common/src/main/java/net/imprex/orebfuscator/config/ProximityConfig.java
+++ b/orebfuscator-common/src/main/java/net/imprex/orebfuscator/config/ProximityConfig.java
@@ -16,7 +16,7 @@ public interface ProximityConfig extends WorldConfig {
 
 	Matrix4f frustumCullingProjectionMatrix();
 
-	boolean useRayCastCheck();
+	boolean rayCastCheckEnabled();
 
 	Iterable<Map.Entry<BlockProperties, Integer>> hiddenBlocks();
 }

--- a/orebfuscator-common/src/main/java/net/imprex/orebfuscator/config/ProximityConfig.java
+++ b/orebfuscator-common/src/main/java/net/imprex/orebfuscator/config/ProximityConfig.java
@@ -18,5 +18,7 @@ public interface ProximityConfig extends WorldConfig {
 
 	boolean rayCastCheckEnabled();
 
+	boolean rayCastCheckOnlyCheckCenter();
+
 	Iterable<Map.Entry<BlockProperties, Integer>> hiddenBlocks();
 }

--- a/orebfuscator-plugin/src/main/java/net/imprex/orebfuscator/config/OrebfuscatorConfig.java
+++ b/orebfuscator-plugin/src/main/java/net/imprex/orebfuscator/config/OrebfuscatorConfig.java
@@ -232,7 +232,7 @@ public class OrebfuscatorConfig implements Config {
 
 	public boolean usesRayCastCheck() {
 		for (ProximityConfig config : this.proximityConfigs) {
-			if (config.useRayCastCheck()) {
+			if (config.rayCastCheckEnabled()) {
 				return true;
 			}
 		}

--- a/orebfuscator-plugin/src/main/java/net/imprex/orebfuscator/config/OrebfuscatorProximityConfig.java
+++ b/orebfuscator-plugin/src/main/java/net/imprex/orebfuscator/config/OrebfuscatorProximityConfig.java
@@ -25,7 +25,8 @@ public class OrebfuscatorProximityConfig extends AbstractWorldConfig implements 
 	private float frustumCullingMinDistanceSquared = 9;
 	private Matrix4f frustumCullingProjectionMatrix;
 
-	private boolean useRayCastCheck = false;
+	private boolean rayCastCheckEnabled = false;
+	private boolean rayCastCheckOnlyCheckCenter = false;
 	private int defaultBlockFlags = (ProximityHeightCondition.MATCH_ALL | BlockFlags.FLAG_USE_BLOCK_BELOW);
 	
 	private boolean usesBlockSpecificConfigs = false;
@@ -66,8 +67,10 @@ public class OrebfuscatorProximityConfig extends AbstractWorldConfig implements 
 		this.frustumCullingProjectionMatrix = new Matrix4f() // create projection matrix with aspect 16:9
 				.perspective(frustumCullingFov, 16f / 9f, 0.01f, 2 * distance);
 
-		this.useRayCastCheck = section.getBoolean("useRayCastCheck",
-				section.getBoolean("useFastGazeCheck", false));
+		this.rayCastCheckEnabled = section.getBoolean("rayCastCheck.enabled",
+				section.getBoolean("useRayCastCheck",
+				section.getBoolean("useFastGazeCheck", false)));
+		this.rayCastCheckOnlyCheckCenter = section.getBoolean("rayCastCheck.onlyCheckCenter", false);
 
 		this.defaultBlockFlags = ProximityHeightCondition.create(minY, maxY);
 		if (section.getBoolean("useBlockBelow", true)) {
@@ -92,7 +95,8 @@ public class OrebfuscatorProximityConfig extends AbstractWorldConfig implements 
 		section.set("frustumCulling.minDistance", frustumCullingMinDistance);
 		section.set("frustumCulling.fov", frustumCullingFov);
 
-		section.set("useRayCastCheck", this.useRayCastCheck);
+		section.set("rayCastCheck.enabled", this.rayCastCheckEnabled);
+		section.set("rayCastCheck.onlyCheckCenter", this.rayCastCheckOnlyCheckCenter);
 		section.set("useBlockBelow", BlockFlags.isUseBlockBelowBitSet(this.defaultBlockFlags));
 
 		this.serializeHiddenBlocks(section, "hiddenBlocks");
@@ -199,8 +203,13 @@ public class OrebfuscatorProximityConfig extends AbstractWorldConfig implements 
 	}
 
 	@Override
-	public boolean useRayCastCheck() {
-		return this.useRayCastCheck;
+	public boolean rayCastCheckEnabled() {
+		return this.rayCastCheckEnabled;
+	}
+
+	@Override
+	public boolean rayCastCheckOnlyCheckCenter() {
+		return this.rayCastCheckOnlyCheckCenter;
 	}
 
 	@Override

--- a/orebfuscator-plugin/src/main/java/net/imprex/orebfuscator/config/OrebfuscatorProximityConfig.java
+++ b/orebfuscator-plugin/src/main/java/net/imprex/orebfuscator/config/OrebfuscatorProximityConfig.java
@@ -204,7 +204,12 @@ public class OrebfuscatorProximityConfig extends AbstractWorldConfig implements 
 
 	@Override
 	public boolean rayCastCheckEnabled() {
-		return this.useRayCastCheck;
+		return this.rayCastCheckEnabled;
+	}
+
+	@Override
+	public boolean rayCastCheckOnlyCheckCenter() {
+		return this.rayCastCheckOnlyCheckCenter;
 	}
 
 	@Override

--- a/orebfuscator-plugin/src/main/java/net/imprex/orebfuscator/config/OrebfuscatorProximityConfig.java
+++ b/orebfuscator-plugin/src/main/java/net/imprex/orebfuscator/config/OrebfuscatorProximityConfig.java
@@ -204,12 +204,7 @@ public class OrebfuscatorProximityConfig extends AbstractWorldConfig implements 
 
 	@Override
 	public boolean rayCastCheckEnabled() {
-		return this.rayCastCheckEnabled;
-	}
-
-	@Override
-	public boolean rayCastCheckOnlyCheckCenter() {
-		return this.rayCastCheckOnlyCheckCenter;
+		return this.useRayCastCheck;
 	}
 
 	@Override

--- a/orebfuscator-plugin/src/main/java/net/imprex/orebfuscator/proximity/ProximityWorker.java
+++ b/orebfuscator-plugin/src/main/java/net/imprex/orebfuscator/proximity/ProximityWorker.java
@@ -65,7 +65,7 @@ public class ProximityWorker {
 		}
 
 		// frustum culling and ray casting both need rotation changes
-		boolean needsRotation = proximityConfig.frustumCullingEnabled() || proximityConfig.useRayCastCheck();
+		boolean needsRotation = proximityConfig.frustumCullingEnabled() || proximityConfig.rayCastCheckEnabled();
 
 		// check if player changed location since last time
 		OrebfuscatorPlayer orebfuscatorPlayer = this.playerMap.get(player);
@@ -132,7 +132,7 @@ public class ProximityWorker {
 					}
 
 					// do ray cast check
-					if (proximityConfig.useRayCastCheck() && !FastGazeUtil.doFastCheck(blockPos, eyeLocation, world)) {
+					if (proximityConfig.rayCastCheckEnabled() && !FastGazeUtil.doFastCheck(blockPos, eyeLocation, world, proximityConfig.rayCastCheckOnlyCheckCenter())) {
 						continue;
 					}
 

--- a/orebfuscator-plugin/src/main/java/net/imprex/orebfuscator/util/FastGazeUtil.java
+++ b/orebfuscator-plugin/src/main/java/net/imprex/orebfuscator/util/FastGazeUtil.java
@@ -11,34 +11,40 @@ public class FastGazeUtil {
 	 * Basic idea here is to take some rays from the considered block to the
 	 * player's eyes, and decide if any of those rays can reach the eyes unimpeded.
 	 *
-	 * @param block  the starting block
-	 * @param eyes   the destination eyes
-	 * @param player the player world we are testing for
+	 * @param pos             the starting block position
+	 * @param eyes            the destination eyes
+	 * @param player          the player world we are testing for
+	 * @param onlyCheckCenter only check block center if true
 	 * @return true if unimpeded path, false otherwise
 	 */
-	public static boolean doFastCheck(BlockPos pos, Location eyes, World player) {
+	public static boolean doFastCheck(BlockPos pos, Location eyes, World player, boolean onlyCheckCenter) {
 		double ex = eyes.getX();
 		double ey = eyes.getY();
 		double ez = eyes.getZ();
 		double x = pos.x;
 		double y = pos.y;
 		double z = pos.z;
-		return // midfaces
-		FastGazeUtil.fastAABBRayCheck(x, y, z, x, y + 0.5, z + 0.5, ex, ey, ez, player)
-				|| FastGazeUtil.fastAABBRayCheck(x, y, z, x + 0.5, y, z + 0.5, ex, ey, ez, player)
-				|| FastGazeUtil.fastAABBRayCheck(x, y, z, x + 0.5, y + 0.5, z, ex, ey, ez, player)
-				|| FastGazeUtil.fastAABBRayCheck(x, y, z, x + 0.5, y + 1.0, z + 0.5, ex, ey, ez, player)
-				|| FastGazeUtil.fastAABBRayCheck(x, y, z, x + 0.5, y + 0.5, z + 1.0, ex, ey, ez, player)
-				|| FastGazeUtil.fastAABBRayCheck(x, y, z, x + 1.0, y + 0.5, z + 0.5, ex, ey, ez, player) ||
-				// corners
-				FastGazeUtil.fastAABBRayCheck(x, y, z, x, y, z, ex, ey, ez, player)
-				|| FastGazeUtil.fastAABBRayCheck(x, y, z, x + 1, y, z, ex, ey, ez, player)
-				|| FastGazeUtil.fastAABBRayCheck(x, y, z, x, y + 1, z, ex, ey, ez, player)
-				|| FastGazeUtil.fastAABBRayCheck(x, y, z, x + 1, y + 1, z, ex, ey, ez, player)
-				|| FastGazeUtil.fastAABBRayCheck(x, y, z, x, y, z + 1, ex, ey, ez, player)
-				|| FastGazeUtil.fastAABBRayCheck(x, y, z, x + 1, y, z + 1, ex, ey, ez, player)
-				|| FastGazeUtil.fastAABBRayCheck(x, y, z, x, y + 1, z + 1, ex, ey, ez, player)
-				|| FastGazeUtil.fastAABBRayCheck(x, y, z, x + 1, y + 1, z + 1, ex, ey, ez, player);
+		if (onlyCheckCenter) {
+			return // center
+				FastGazeUtil.fastAABBRayCheck(x, y, z, x + 0.5, y + 0.5, z + 0.5, ex, ey, ez, player);
+		} else {
+			return // midfaces
+				FastGazeUtil.fastAABBRayCheck(x, y, z, x, y + 0.5, z + 0.5, ex, ey, ez, player)
+					|| FastGazeUtil.fastAABBRayCheck(x, y, z, x + 0.5, y, z + 0.5, ex, ey, ez, player)
+					|| FastGazeUtil.fastAABBRayCheck(x, y, z, x + 0.5, y + 0.5, z, ex, ey, ez, player)
+					|| FastGazeUtil.fastAABBRayCheck(x, y, z, x + 0.5, y + 1.0, z + 0.5, ex, ey, ez, player)
+					|| FastGazeUtil.fastAABBRayCheck(x, y, z, x + 0.5, y + 0.5, z + 1.0, ex, ey, ez, player)
+					|| FastGazeUtil.fastAABBRayCheck(x, y, z, x + 1.0, y + 0.5, z + 0.5, ex, ey, ez, player) ||
+					// corners
+					FastGazeUtil.fastAABBRayCheck(x, y, z, x, y, z, ex, ey, ez, player)
+					|| FastGazeUtil.fastAABBRayCheck(x, y, z, x + 1, y, z, ex, ey, ez, player)
+					|| FastGazeUtil.fastAABBRayCheck(x, y, z, x, y + 1, z, ex, ey, ez, player)
+					|| FastGazeUtil.fastAABBRayCheck(x, y, z, x + 1, y + 1, z, ex, ey, ez, player)
+					|| FastGazeUtil.fastAABBRayCheck(x, y, z, x, y, z + 1, ex, ey, ez, player)
+					|| FastGazeUtil.fastAABBRayCheck(x, y, z, x + 1, y, z + 1, ex, ey, ez, player)
+					|| FastGazeUtil.fastAABBRayCheck(x, y, z, x, y + 1, z + 1, ex, ey, ez, player)
+					|| FastGazeUtil.fastAABBRayCheck(x, y, z, x + 1, y + 1, z + 1, ex, ey, ez, player);
+		}
 	}
 
 	public static boolean fastAABBRayCheck(double bx, double by, double bz, double x, double y, double z, double ex,

--- a/orebfuscator-plugin/src/main/resources/config/config-1.10.yml
+++ b/orebfuscator-plugin/src/main/resources/config/config-1.10.yml
@@ -136,7 +136,9 @@ proximity:
       enabled: true
       minDistance: 3
       fov: 80
-    useRayCastCheck: false
+    rayCastCheck:
+      enabled: false
+      onlyCheckCenter: false
     useBlockBelow: true
     hiddenBlocks:
       minecraft:mossy_cobblestone: {}
@@ -169,7 +171,9 @@ proximity:
       enabled: true
       minDistance: 3
       fov: 80
-    useRayCastCheck: false
+    rayCastCheck:
+      enabled: false
+      onlyCheckCenter: false
     useBlockBelow: true
     hiddenBlocks:
       minecraft:chest: {}
@@ -199,7 +203,9 @@ proximity:
       enabled: true
       minDistance: 3
       fov: 80
-    useRayCastCheck: false
+    rayCastCheck:
+      enabled: false
+      onlyCheckCenter: false
     useBlockBelow: true
     hiddenBlocks:
       minecraft:chest: {}

--- a/orebfuscator-plugin/src/main/resources/config/config-1.11.yml
+++ b/orebfuscator-plugin/src/main/resources/config/config-1.11.yml
@@ -184,7 +184,9 @@ proximity:
       enabled: true
       minDistance: 3
       fov: 80
-    useRayCastCheck: false
+    rayCastCheck:
+      enabled: false
+      onlyCheckCenter: false
     useBlockBelow: true
     hiddenBlocks:
       minecraft:mossy_cobblestone: {}
@@ -233,7 +235,9 @@ proximity:
       enabled: true
       minDistance: 3
       fov: 80
-    useRayCastCheck: false
+    rayCastCheck:
+      enabled: false
+      onlyCheckCenter: false
     useBlockBelow: true
     hiddenBlocks:
       minecraft:chest: {}
@@ -279,7 +283,9 @@ proximity:
       enabled: true
       minDistance: 3
       fov: 80
-    useRayCastCheck: false
+    rayCastCheck:
+      enabled: false
+      onlyCheckCenter: false
     useBlockBelow: true
     hiddenBlocks:
       minecraft:chest: {}

--- a/orebfuscator-plugin/src/main/resources/config/config-1.12.yml
+++ b/orebfuscator-plugin/src/main/resources/config/config-1.12.yml
@@ -184,7 +184,9 @@ proximity:
       enabled: true
       minDistance: 3
       fov: 80
-    useRayCastCheck: false
+    rayCastCheck:
+      enabled: false
+      onlyCheckCenter: false
     useBlockBelow: true
     hiddenBlocks:
       minecraft:mossy_cobblestone: {}
@@ -233,7 +235,9 @@ proximity:
       enabled: true
       minDistance: 3
       fov: 80
-    useRayCastCheck: false
+    rayCastCheck:
+      enabled: false
+      onlyCheckCenter: false
     useBlockBelow: true
     hiddenBlocks:
       minecraft:chest: {}
@@ -279,7 +283,9 @@ proximity:
       enabled: true
       minDistance: 3
       fov: 80
-    useRayCastCheck: false
+    rayCastCheck:
+      enabled: false
+      onlyCheckCenter: false
     useBlockBelow: true
     hiddenBlocks:
       minecraft:chest: {}

--- a/orebfuscator-plugin/src/main/resources/config/config-1.13.yml
+++ b/orebfuscator-plugin/src/main/resources/config/config-1.13.yml
@@ -187,7 +187,8 @@ proximity:
       enabled: true
       minDistance: 3
       fov: 80
-    useRayCastCheck: false
+    rayCastCheck:
+  enabled: false
     useBlockBelow: true
     hiddenBlocks:
       minecraft:mossy_cobblestone: {}
@@ -237,7 +238,8 @@ proximity:
       enabled: true
       minDistance: 3
       fov: 80
-    useRayCastCheck: false
+    rayCastCheck:
+  enabled: false
     useBlockBelow: true
     hiddenBlocks:
       minecraft:chest: {}
@@ -284,7 +286,9 @@ proximity:
       enabled: true
       minDistance: 3
       fov: 80
-    useRayCastCheck: false
+    rayCastCheck:
+      enabled: false
+      onlyCheckCenter: false
     useBlockBelow: true
     hiddenBlocks:
       minecraft:chest: {}

--- a/orebfuscator-plugin/src/main/resources/config/config-1.14.yml
+++ b/orebfuscator-plugin/src/main/resources/config/config-1.14.yml
@@ -187,7 +187,9 @@ proximity:
       enabled: true
       minDistance: 3
       fov: 80
-    useRayCastCheck: false
+    rayCastCheck:
+      enabled: false
+      onlyCheckCenter: false
     useBlockBelow: true
     hiddenBlocks:
       minecraft:mossy_cobblestone: {}
@@ -247,7 +249,9 @@ proximity:
       enabled: true
       minDistance: 3
       fov: 80
-    useRayCastCheck: false
+    rayCastCheck:
+      enabled: false
+      onlyCheckCenter: false
     useBlockBelow: true
     hiddenBlocks:
       minecraft:chest: {}
@@ -304,7 +308,9 @@ proximity:
       enabled: true
       minDistance: 3
       fov: 80
-    useRayCastCheck: false
+    rayCastCheck:
+      enabled: false
+      onlyCheckCenter: false
     useBlockBelow: true
     hiddenBlocks:
       minecraft:chest: {}

--- a/orebfuscator-plugin/src/main/resources/config/config-1.15.yml
+++ b/orebfuscator-plugin/src/main/resources/config/config-1.15.yml
@@ -187,7 +187,9 @@ proximity:
       enabled: true
       minDistance: 3
       fov: 80
-    useRayCastCheck: false
+    rayCastCheck:
+      enabled: false
+      onlyCheckCenter: false
     useBlockBelow: true
     hiddenBlocks:
       minecraft:mossy_cobblestone: {}
@@ -249,7 +251,9 @@ proximity:
       enabled: true
       minDistance: 3
       fov: 80
-    useRayCastCheck: false
+    rayCastCheck:
+      enabled: false
+      onlyCheckCenter: false
     useBlockBelow: true
     hiddenBlocks:
       minecraft:chest: {}
@@ -308,7 +312,9 @@ proximity:
       enabled: true
       minDistance: 3
       fov: 80
-    useRayCastCheck: false
+    rayCastCheck:
+      enabled: false
+      onlyCheckCenter: false
     useBlockBelow: true
     hiddenBlocks:
       minecraft:chest: {}

--- a/orebfuscator-plugin/src/main/resources/config/config-1.16.yml
+++ b/orebfuscator-plugin/src/main/resources/config/config-1.16.yml
@@ -194,7 +194,9 @@ proximity:
       enabled: true
       minDistance: 3
       fov: 80
-    useRayCastCheck: false
+    rayCastCheck:
+      enabled: false
+      onlyCheckCenter: false
     useBlockBelow: true
     hiddenBlocks:
       minecraft:mossy_cobblestone: {}
@@ -256,7 +258,9 @@ proximity:
       enabled: true
       minDistance: 3
       fov: 80
-    useRayCastCheck: false
+    rayCastCheck:
+      enabled: false
+      onlyCheckCenter: false
     useBlockBelow: true
     hiddenBlocks:
       minecraft:chest: {}
@@ -318,7 +322,9 @@ proximity:
       enabled: true
       minDistance: 3
       fov: 80
-    useRayCastCheck: false
+    rayCastCheck:
+      enabled: false
+      onlyCheckCenter: false
     useBlockBelow: true
     hiddenBlocks:
       minecraft:chest: {}

--- a/orebfuscator-plugin/src/main/resources/config/config-1.17.yml
+++ b/orebfuscator-plugin/src/main/resources/config/config-1.17.yml
@@ -221,7 +221,9 @@ proximity:
       enabled: true
       minDistance: 3
       fov: 80
-    useRayCastCheck: false
+    rayCastCheck:
+      enabled: false
+      onlyCheckCenter: false
     useBlockBelow: true
     hiddenBlocks:
       minecraft:mossy_cobblestone: {}
@@ -290,7 +292,9 @@ proximity:
       enabled: true
       minDistance: 3
       fov: 80
-    useRayCastCheck: false
+    rayCastCheck:
+      enabled: false
+      onlyCheckCenter: false
     useBlockBelow: true
     hiddenBlocks:
       minecraft:chest: {}
@@ -352,7 +356,9 @@ proximity:
       enabled: true
       minDistance: 3
       fov: 80
-    useRayCastCheck: false
+    rayCastCheck:
+      enabled: false
+      onlyCheckCenter: false
     useBlockBelow: true
     hiddenBlocks:
       minecraft:chest: {}

--- a/orebfuscator-plugin/src/main/resources/config/config-1.18.yml
+++ b/orebfuscator-plugin/src/main/resources/config/config-1.18.yml
@@ -221,7 +221,9 @@ proximity:
       enabled: true
       minDistance: 3
       fov: 80
-    useRayCastCheck: false
+    rayCastCheck:
+      enabled: false
+      onlyCheckCenter: false
     useBlockBelow: true
     hiddenBlocks:
       minecraft:mossy_cobblestone: {}
@@ -290,7 +292,9 @@ proximity:
       enabled: true
       minDistance: 3
       fov: 80
-    useRayCastCheck: false
+    rayCastCheck:
+      enabled: false
+      onlyCheckCenter: false
     useBlockBelow: true
     hiddenBlocks:
       minecraft:chest: {}
@@ -352,7 +356,9 @@ proximity:
       enabled: true
       minDistance: 3
       fov: 80
-    useRayCastCheck: false
+    rayCastCheck:
+      enabled: false
+      onlyCheckCenter: false
     useBlockBelow: true
     hiddenBlocks:
       minecraft:chest: {}

--- a/orebfuscator-plugin/src/main/resources/config/config-1.19.yml
+++ b/orebfuscator-plugin/src/main/resources/config/config-1.19.yml
@@ -221,7 +221,9 @@ proximity:
       enabled: true
       minDistance: 3
       fov: 80
-    useRayCastCheck: false
+    rayCastCheck:
+      enabled: false
+      onlyCheckCenter: false
     useBlockBelow: true
     hiddenBlocks:
       minecraft:mossy_cobblestone: {}
@@ -290,7 +292,9 @@ proximity:
       enabled: true
       minDistance: 3
       fov: 80
-    useRayCastCheck: false
+    rayCastCheck:
+      enabled: false
+      onlyCheckCenter: false
     useBlockBelow: true
     hiddenBlocks:
       minecraft:chest: {}
@@ -352,7 +356,9 @@ proximity:
       enabled: true
       minDistance: 3
       fov: 80
-    useRayCastCheck: false
+    rayCastCheck:
+      enabled: false
+      onlyCheckCenter: false
     useBlockBelow: true
     hiddenBlocks:
       minecraft:chest: {}

--- a/orebfuscator-plugin/src/main/resources/config/config-1.20.yml
+++ b/orebfuscator-plugin/src/main/resources/config/config-1.20.yml
@@ -221,7 +221,9 @@ proximity:
       enabled: true
       minDistance: 3
       fov: 80
-    useRayCastCheck: false
+    rayCastCheck:
+      enabled: false
+      onlyCheckCenter: false
     useBlockBelow: true
     hiddenBlocks:
       minecraft:mossy_cobblestone: {}
@@ -290,7 +292,9 @@ proximity:
       enabled: true
       minDistance: 3
       fov: 80
-    useRayCastCheck: false
+    rayCastCheck:
+      enabled: false
+      onlyCheckCenter: false
     useBlockBelow: true
     hiddenBlocks:
       minecraft:chest: {}
@@ -352,7 +356,9 @@ proximity:
       enabled: true
       minDistance: 3
       fov: 80
-    useRayCastCheck: false
+    rayCastCheck:
+      enabled: false
+      onlyCheckCenter: false
     useBlockBelow: true
     hiddenBlocks:
       minecraft:chest: {}

--- a/orebfuscator-plugin/src/main/resources/config/config-1.9.yml
+++ b/orebfuscator-plugin/src/main/resources/config/config-1.9.yml
@@ -136,7 +136,9 @@ proximity:
       enabled: true
       minDistance: 3
       fov: 80
-    useRayCastCheck: false
+    rayCastCheck:
+      enabled: false
+      onlyCheckCenter: false
     useBlockBelow: true
     hiddenBlocks:
       minecraft:mossy_cobblestone: {}
@@ -169,7 +171,9 @@ proximity:
       enabled: true
       minDistance: 3
       fov: 80
-    useRayCastCheck: false
+    rayCastCheck:
+      enabled: false
+      onlyCheckCenter: false
     useBlockBelow: true
     hiddenBlocks:
       minecraft:chest: {}
@@ -199,7 +203,9 @@ proximity:
       enabled: true
       minDistance: 3
       fov: 80
-    useRayCastCheck: false
+    rayCastCheck:
+      enabled: false
+      onlyCheckCenter: false
     useBlockBelow: true
     hiddenBlocks:
       minecraft:chest: {}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Disabling this option increases efficiency by reducing the number of ray casts

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
No

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The original ray cast check checks all corners and edges of the block. Disabling this option allows you to check only the center point of the block, reducing the performance cost of ray cast.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Local server

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
