### PR TITLE
[#423] Fix API to be usable with folia region threads

### DIFF
--- a/orebfuscator-api-example/pom.xml
+++ b/orebfuscator-api-example/pom.xml
@@ -14,16 +14,25 @@
 
 	<dependencies>
 		<dependency>
-			<groupId>org.spigotmc</groupId>
-			<artifactId>spigot-api</artifactId>
-			<version>1.18-R0.1-SNAPSHOT</version>
-			<scope>provided</scope>
-		</dependency>
-		<dependency>
 			<groupId>net.imprex</groupId>
 			<artifactId>orebfuscator-api</artifactId>
 			<version>${revision}</version>
 			<scope>provided</scope>
 		</dependency>
+		<dependency>
+			<groupId>dev.folia</groupId>
+			<artifactId>folia-api</artifactId>
+			<version>1.21.4-R0.1-SNAPSHOT</version>
+			<scope>provided</scope>
+		</dependency>
 	</dependencies>
+	
+	<build>
+		<resources>
+			<resource>
+				<directory>src/main/resources</directory>
+				<filtering>true</filtering>
+			</resource>
+		</resources>
+	</build>
 </project>

--- a/orebfuscator-api-example/src/main/resources/plugin.yml
+++ b/orebfuscator-api-example/src/main/resources/plugin.yml
@@ -1,6 +1,7 @@
-api-version: 1.18
+api-version: 1.21
+folia-supported: true
 
-name: orebfuscator-api-example
+name: ${project.name}
 version: ${project.version}
 
 main: net.imprex.api.example.Example

--- a/orebfuscator-api/pom.xml
+++ b/orebfuscator-api/pom.xml
@@ -16,7 +16,7 @@
 		<dependency>
 			<groupId>org.spigotmc</groupId>
 			<artifactId>spigot-api</artifactId>
-			<version>1.9.4-R0.1-SNAPSHOT</version>
+			<version>${dependency.bukkit.version}</version>
 			<scope>provided</scope>
 		</dependency>
 	</dependencies>

--- a/orebfuscator-api/src/main/java/net/imprex/orebfuscator/api/OrebfuscatorService.java
+++ b/orebfuscator-api/src/main/java/net/imprex/orebfuscator/api/OrebfuscatorService.java
@@ -12,7 +12,7 @@ import org.bukkit.block.Block;
  * 
  * <p>
  * All calls to this service are expected to originate from the servers
- * main-thread.
+ * main-thread or in case of folia from a region thread (never the global region thread).
  * </p>
  * 
  * @since 5.2.0

--- a/orebfuscator-compatibility/orebfuscator-compatibility-api/src/main/java/net/imprex/orebfuscator/OrebfuscatorCompatibility.java
+++ b/orebfuscator-compatibility/orebfuscator-compatibility-api/src/main/java/net/imprex/orebfuscator/OrebfuscatorCompatibility.java
@@ -45,6 +45,10 @@ public class OrebfuscatorCompatibility {
 		OFCLogger.debug("Compatibility layer successfully loaded");
 	}
 
+	public static boolean isGameThread() {
+		return instance.isGameThread();
+	}
+
 	public static void runForPlayer(Player player, Runnable runnable) {
 		instance.getScheduler().runForPlayer(player, runnable);
 	}

--- a/orebfuscator-compatibility/orebfuscator-compatibility-api/src/main/java/net/imprex/orebfuscator/compatibility/CompatibilityLayer.java
+++ b/orebfuscator-compatibility/orebfuscator-compatibility-api/src/main/java/net/imprex/orebfuscator/compatibility/CompatibilityLayer.java
@@ -9,6 +9,8 @@ import net.imprex.orebfuscator.util.ChunkPosition;
 
 public interface CompatibilityLayer {
 
+	boolean isGameThread();
+
 	CompatibilityScheduler getScheduler();
 
 	CompletableFuture<ReadOnlyChunk[]> getNeighboringChunks(World world, ChunkPosition position);

--- a/orebfuscator-compatibility/orebfuscator-compatibility-bukkit/src/main/java/net/imprex/orebfuscator/compatibility/bukkit/BukkitCompatibilityLayer.java
+++ b/orebfuscator-compatibility/orebfuscator-compatibility-bukkit/src/main/java/net/imprex/orebfuscator/compatibility/bukkit/BukkitCompatibilityLayer.java
@@ -13,12 +13,19 @@ import net.imprex.orebfuscator.util.ChunkPosition;
 
 public class BukkitCompatibilityLayer implements CompatibilityLayer {
 
+	private final Thread mainThread = Thread.currentThread();
+
 	private final BukkitScheduler scheduler;
 	private final BukkitChunkLoader chunkLoader;
 
 	public BukkitCompatibilityLayer(Plugin plugin, Config config) {
 		this.scheduler = new BukkitScheduler(plugin);
 		this.chunkLoader = new BukkitChunkLoader(plugin, config);
+	}
+
+	@Override
+	public boolean isGameThread() {
+		return Thread.currentThread() == this.mainThread;
 	}
 
 	@Override

--- a/orebfuscator-compatibility/orebfuscator-compatibility-folia/src/main/java/net/imprex/orebfuscator/compatibility/folia/FoliaCompatibilityLayer.java
+++ b/orebfuscator-compatibility/orebfuscator-compatibility-folia/src/main/java/net/imprex/orebfuscator/compatibility/folia/FoliaCompatibilityLayer.java
@@ -8,10 +8,25 @@ import net.imprex.orebfuscator.config.Config;
 
 public class FoliaCompatibilityLayer extends AbstractPaperCompatibilityLayer {
 
+	private static final Class<?> TICK_THREAD_CLASS = getTickThreadClass();
+
+	private static Class<?> getTickThreadClass() {
+		try {
+			return Class.forName("io.papermc.paper.threadedregions.TickRegionScheduler$TickThreadRunner");
+		} catch (ClassNotFoundException e) {
+			throw new RuntimeException("Can't find tick thread class for folia", e);
+		}
+	}
+
 	private final FoliaScheduler scheduler;
 
 	public FoliaCompatibilityLayer(Plugin plugin, Config config) {
 		this.scheduler = new FoliaScheduler(plugin);
+	}
+
+	@Override
+	public boolean isGameThread() {
+		return TICK_THREAD_CLASS.isInstance(Thread.currentThread());
 	}
 
 	@Override

--- a/orebfuscator-compatibility/orebfuscator-compatibility-paper/src/main/java/net/imprex/orebfuscator/compatibility/paper/PaperCompatibilityLayer.java
+++ b/orebfuscator-compatibility/orebfuscator-compatibility-paper/src/main/java/net/imprex/orebfuscator/compatibility/paper/PaperCompatibilityLayer.java
@@ -8,10 +8,17 @@ import net.imprex.orebfuscator.config.Config;
 
 public class PaperCompatibilityLayer extends AbstractPaperCompatibilityLayer {
 
+	private final Thread mainThread = Thread.currentThread();
+
 	private final BukkitScheduler scheduler;
 
 	public PaperCompatibilityLayer(Plugin plugin, Config config) {
 		this.scheduler = new BukkitScheduler(plugin);
+	}
+
+	@Override
+	public boolean isGameThread() {
+		return Thread.currentThread() == this.mainThread;
 	}
 
 	@Override

--- a/orebfuscator-plugin/src/main/java/net/imprex/orebfuscator/DefaultOrebfuscatorService.java
+++ b/orebfuscator-plugin/src/main/java/net/imprex/orebfuscator/DefaultOrebfuscatorService.java
@@ -11,18 +11,16 @@ import net.imprex.orebfuscator.obfuscation.ObfuscationSystem;
 
 public final class DefaultOrebfuscatorService implements OrebfuscatorService {
 
-	private final Orebfuscator orebfuscator;
 	private final ObfuscationSystem obfuscationSystem;
 
 	public DefaultOrebfuscatorService(Orebfuscator orebfuscator) {
-		this.orebfuscator = orebfuscator;
 		this.obfuscationSystem = orebfuscator.getObfuscationSystem();
 	}
 
 	@Override
 	public final void deobfuscate(Collection<? extends Block> blocks) {
-		if (!this.orebfuscator.isGameThread()) {
-            throw new IllegalStateException("Asynchronous deobfuscation!");
+		if (!OrebfuscatorCompatibility.isGameThread()) {
+			throw new IllegalStateException("Asynchronous deobfuscation! " + Thread.currentThread());
 		} else if (blocks == null || blocks.isEmpty()) {
 			throw new IllegalArgumentException("block list is null or empty");
 		}

--- a/orebfuscator-plugin/src/main/java/net/imprex/orebfuscator/Orebfuscator.java
+++ b/orebfuscator-plugin/src/main/java/net/imprex/orebfuscator/Orebfuscator.java
@@ -25,8 +25,6 @@ public class Orebfuscator extends JavaPlugin implements Listener {
 
 	public static final ThreadGroup THREAD_GROUP = new ThreadGroup("orebfuscator");
 
-	private final Thread mainThread = Thread.currentThread();
-
 	private OrebfuscatorStatistics statistics;
 	private OrebfuscatorConfig config;
 	private OrebfuscatorPlayerMap playerMap;
@@ -135,10 +133,6 @@ public class Orebfuscator extends JavaPlugin implements Listener {
 			HandlerList.unregisterAll(listener);
 			Bukkit.getPluginManager().disablePlugin(this);
 		}
-	}
-
-	public boolean isGameThread() {
-		return Thread.currentThread() == this.mainThread;
 	}
 
 	public OrebfuscatorStatistics getStatistics() {

--- a/orebfuscator-plugin/src/main/java/net/imprex/orebfuscator/cache/ObfuscationCache.java
+++ b/orebfuscator-plugin/src/main/java/net/imprex/orebfuscator/cache/ObfuscationCache.java
@@ -17,7 +17,6 @@ import net.imprex.orebfuscator.util.ChunkPosition;
 
 public class ObfuscationCache {
 
-	private final Orebfuscator orebfuscator;
 	private final CacheConfig cacheConfig;
 	private final OrebfuscatorStatistics statistics;
 
@@ -25,7 +24,6 @@ public class ObfuscationCache {
 	private final AsyncChunkSerializer serializer;
 
 	public ObfuscationCache(Orebfuscator orebfuscator) {
-		this.orebfuscator = orebfuscator;
 		this.cacheConfig = orebfuscator.getOrebfuscatorConfig().cache();
 		this.statistics = orebfuscator.getStatistics();
 
@@ -52,7 +50,7 @@ public class ObfuscationCache {
 
 		// don't serialize invalidated chunks since this would require locking the main
 		// thread and wouldn't bring a huge improvement
-		if (this.cacheConfig.enableDiskCache() && notification.wasEvicted() && !this.orebfuscator.isGameThread()) {
+		if (this.cacheConfig.enableDiskCache() && notification.wasEvicted() && !OrebfuscatorCompatibility.isGameThread()) {
 			this.serializer.write(notification.getKey(), notification.getValue());
 		}
 	}


### PR DESCRIPTION
## Description
Allow deobfuscation through our API in region thread if folia is detected.

## Related Issue
closes #423 

## How Has This Been Tested?
Successfully tested with spigot (1.21.5), paper (1.21.4), folia (1.21.4)

## Types of Changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
