### PR TITLE
[#454] Fix region file cache on paper

### DIFF
--- a/orebfuscator-core/src/main/java/dev/imprex/orebfuscator/cache/AbstractRegionFileCache.java
+++ b/orebfuscator-core/src/main/java/dev/imprex/orebfuscator/cache/AbstractRegionFileCache.java
@@ -10,10 +10,26 @@ import java.util.Objects;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import dev.imprex.orebfuscator.config.api.CacheConfig;
+import dev.imprex.orebfuscator.reflect.Reflector;
+import dev.imprex.orebfuscator.reflect.accessor.MethodAccessor;
 import dev.imprex.orebfuscator.util.ChunkCacheKey;
 import dev.imprex.orebfuscator.util.SimpleCache;
 
 public abstract class AbstractRegionFileCache<T> {
+
+  private static MethodAccessor serverGetServer;
+
+  protected static <T> T serverHandle(Object server, Class<T> targetClass) {
+    if (serverGetServer == null) {
+      serverGetServer = Reflector.of(server.getClass()).method()
+          .banStatic()
+          .nameIs("getServer")
+          .returnType().is(targetClass)
+          .parameterCount(0)
+          .firstOrThrow();
+    }
+    return targetClass.cast(serverGetServer.invoke(server));
+  }
 
   protected final ReadWriteLock lock = new ReentrantReadWriteLock(true);
   protected final Map<Path, T> regionFiles;

--- a/orebfuscator-nms/orebfuscator-nms-v1_16_R1/src/main/java/net/imprex/orebfuscator/nms/v1_16_R1/RegionFileCache.java
+++ b/orebfuscator-nms/orebfuscator-nms-v1_16_R1/src/main/java/net/imprex/orebfuscator/nms/v1_16_R1/RegionFileCache.java
@@ -6,12 +6,12 @@ import java.io.IOException;
 import java.nio.file.Path;
 
 import org.bukkit.Bukkit;
-import org.bukkit.craftbukkit.v1_16_R1.CraftServer;
 
 import dev.imprex.orebfuscator.cache.AbstractRegionFileCache;
 import dev.imprex.orebfuscator.config.api.CacheConfig;
 import dev.imprex.orebfuscator.util.ChunkCacheKey;
 import net.minecraft.server.v1_16_R1.ChunkCoordIntPair;
+import net.minecraft.server.v1_16_R1.DedicatedServer;
 import net.minecraft.server.v1_16_R1.RegionFile;
 import net.minecraft.server.v1_16_R1.RegionFileCompression;
 
@@ -23,7 +23,7 @@ public class RegionFileCache extends AbstractRegionFileCache<RegionFile> {
 
   @Override
   protected RegionFile createRegionFile(Path path) throws IOException {
-    boolean isSyncChunkWrites = ((CraftServer) Bukkit.getServer()).getServer().isSyncChunkWrites();
+    boolean isSyncChunkWrites = serverHandle(Bukkit.getServer(), DedicatedServer.class).isSyncChunkWrites();
     return new RegionFile(path, path.getParent(), RegionFileCompression.c, isSyncChunkWrites);
   }
 

--- a/orebfuscator-nms/orebfuscator-nms-v1_16_R2/src/main/java/net/imprex/orebfuscator/nms/v1_16_R2/RegionFileCache.java
+++ b/orebfuscator-nms/orebfuscator-nms-v1_16_R2/src/main/java/net/imprex/orebfuscator/nms/v1_16_R2/RegionFileCache.java
@@ -6,12 +6,12 @@ import java.io.IOException;
 import java.nio.file.Path;
 
 import org.bukkit.Bukkit;
-import org.bukkit.craftbukkit.v1_16_R2.CraftServer;
 
 import dev.imprex.orebfuscator.cache.AbstractRegionFileCache;
 import dev.imprex.orebfuscator.config.api.CacheConfig;
 import dev.imprex.orebfuscator.util.ChunkCacheKey;
 import net.minecraft.server.v1_16_R2.ChunkCoordIntPair;
+import net.minecraft.server.v1_16_R2.DedicatedServer;
 import net.minecraft.server.v1_16_R2.RegionFile;
 import net.minecraft.server.v1_16_R2.RegionFileCompression;
 
@@ -23,7 +23,7 @@ public class RegionFileCache extends AbstractRegionFileCache<RegionFile> {
 
   @Override
   protected RegionFile createRegionFile(Path path) throws IOException {
-    boolean isSyncChunkWrites = ((CraftServer) Bukkit.getServer()).getServer().isSyncChunkWrites();
+    boolean isSyncChunkWrites = serverHandle(Bukkit.getServer(), DedicatedServer.class).isSyncChunkWrites();
     return new RegionFile(path, path.getParent(), RegionFileCompression.c, isSyncChunkWrites);
   }
 

--- a/orebfuscator-nms/orebfuscator-nms-v1_16_R3/src/main/java/net/imprex/orebfuscator/nms/v1_16_R3/RegionFileCache.java
+++ b/orebfuscator-nms/orebfuscator-nms-v1_16_R3/src/main/java/net/imprex/orebfuscator/nms/v1_16_R3/RegionFileCache.java
@@ -6,12 +6,12 @@ import java.io.IOException;
 import java.nio.file.Path;
 
 import org.bukkit.Bukkit;
-import org.bukkit.craftbukkit.v1_16_R3.CraftServer;
 
 import dev.imprex.orebfuscator.cache.AbstractRegionFileCache;
 import dev.imprex.orebfuscator.config.api.CacheConfig;
 import dev.imprex.orebfuscator.util.ChunkCacheKey;
 import net.minecraft.server.v1_16_R3.ChunkCoordIntPair;
+import net.minecraft.server.v1_16_R3.DedicatedServer;
 import net.minecraft.server.v1_16_R3.RegionFile;
 import net.minecraft.server.v1_16_R3.RegionFileCompression;
 
@@ -23,7 +23,7 @@ public class RegionFileCache extends AbstractRegionFileCache<RegionFile> {
 
   @Override
   protected RegionFile createRegionFile(Path path) throws IOException {
-    boolean isSyncChunkWrites = ((CraftServer) Bukkit.getServer()).getServer().isSyncChunkWrites();
+    boolean isSyncChunkWrites = serverHandle(Bukkit.getServer(), DedicatedServer.class).isSyncChunkWrites();
     return new RegionFile(path, path.getParent(), RegionFileCompression.c, isSyncChunkWrites);
   }
 

--- a/orebfuscator-nms/orebfuscator-nms-v1_17_R1/src/main/java/net/imprex/orebfuscator/nms/v1_17_R1/RegionFileCache.java
+++ b/orebfuscator-nms/orebfuscator-nms-v1_17_R1/src/main/java/net/imprex/orebfuscator/nms/v1_17_R1/RegionFileCache.java
@@ -6,11 +6,11 @@ import java.io.IOException;
 import java.nio.file.Path;
 
 import org.bukkit.Bukkit;
-import org.bukkit.craftbukkit.v1_17_R1.CraftServer;
 
 import dev.imprex.orebfuscator.cache.AbstractRegionFileCache;
 import dev.imprex.orebfuscator.config.api.CacheConfig;
 import dev.imprex.orebfuscator.util.ChunkCacheKey;
+import net.minecraft.server.dedicated.DedicatedServer;
 import net.minecraft.world.level.ChunkPos;
 import net.minecraft.world.level.chunk.storage.RegionFile;
 import net.minecraft.world.level.chunk.storage.RegionFileVersion;
@@ -23,7 +23,7 @@ public class RegionFileCache extends AbstractRegionFileCache<RegionFile> {
 
   @Override
   protected RegionFile createRegionFile(Path path) throws IOException {
-    boolean isSyncChunkWrites = ((CraftServer) Bukkit.getServer()).getServer().forceSynchronousWrites();
+    boolean isSyncChunkWrites = serverHandle(Bukkit.getServer(), DedicatedServer.class).forceSynchronousWrites();
     return new RegionFile(path, path.getParent(), RegionFileVersion.VERSION_NONE, isSyncChunkWrites);
   }
 

--- a/orebfuscator-nms/orebfuscator-nms-v1_18_R1/src/main/java/net/imprex/orebfuscator/nms/v1_18_R1/RegionFileCache.java
+++ b/orebfuscator-nms/orebfuscator-nms-v1_18_R1/src/main/java/net/imprex/orebfuscator/nms/v1_18_R1/RegionFileCache.java
@@ -6,11 +6,11 @@ import java.io.IOException;
 import java.nio.file.Path;
 
 import org.bukkit.Bukkit;
-import org.bukkit.craftbukkit.v1_18_R1.CraftServer;
 
 import dev.imprex.orebfuscator.cache.AbstractRegionFileCache;
 import dev.imprex.orebfuscator.config.api.CacheConfig;
 import dev.imprex.orebfuscator.util.ChunkCacheKey;
+import net.minecraft.server.dedicated.DedicatedServer;
 import net.minecraft.world.level.ChunkPos;
 import net.minecraft.world.level.chunk.storage.RegionFile;
 import net.minecraft.world.level.chunk.storage.RegionFileVersion;
@@ -23,7 +23,7 @@ public class RegionFileCache extends AbstractRegionFileCache<RegionFile> {
 
   @Override
   protected RegionFile createRegionFile(Path path) throws IOException {
-    boolean isSyncChunkWrites = ((CraftServer) Bukkit.getServer()).getServer().forceSynchronousWrites();
+    boolean isSyncChunkWrites = serverHandle(Bukkit.getServer(), DedicatedServer.class).forceSynchronousWrites();
     return new RegionFile(path, path.getParent(), RegionFileVersion.VERSION_NONE, isSyncChunkWrites);
   }
 

--- a/orebfuscator-nms/orebfuscator-nms-v1_18_R2/src/main/java/net/imprex/orebfuscator/nms/v1_18_R2/RegionFileCache.java
+++ b/orebfuscator-nms/orebfuscator-nms-v1_18_R2/src/main/java/net/imprex/orebfuscator/nms/v1_18_R2/RegionFileCache.java
@@ -6,11 +6,11 @@ import java.io.IOException;
 import java.nio.file.Path;
 
 import org.bukkit.Bukkit;
-import org.bukkit.craftbukkit.v1_18_R2.CraftServer;
 
 import dev.imprex.orebfuscator.cache.AbstractRegionFileCache;
 import dev.imprex.orebfuscator.config.api.CacheConfig;
 import dev.imprex.orebfuscator.util.ChunkCacheKey;
+import net.minecraft.server.dedicated.DedicatedServer;
 import net.minecraft.world.level.ChunkPos;
 import net.minecraft.world.level.chunk.storage.RegionFile;
 import net.minecraft.world.level.chunk.storage.RegionFileVersion;
@@ -23,7 +23,7 @@ public class RegionFileCache extends AbstractRegionFileCache<RegionFile> {
 
   @Override
   protected RegionFile createRegionFile(Path path) throws IOException {
-    boolean isSyncChunkWrites = ((CraftServer) Bukkit.getServer()).getServer().forceSynchronousWrites();
+    boolean isSyncChunkWrites = serverHandle(Bukkit.getServer(), DedicatedServer.class).forceSynchronousWrites();
     return new RegionFile(path, path.getParent(), RegionFileVersion.VERSION_NONE, isSyncChunkWrites);
   }
 

--- a/orebfuscator-nms/orebfuscator-nms-v1_19_R1/src/main/java/net/imprex/orebfuscator/nms/v1_19_R1/RegionFileCache.java
+++ b/orebfuscator-nms/orebfuscator-nms-v1_19_R1/src/main/java/net/imprex/orebfuscator/nms/v1_19_R1/RegionFileCache.java
@@ -6,11 +6,11 @@ import java.io.IOException;
 import java.nio.file.Path;
 
 import org.bukkit.Bukkit;
-import org.bukkit.craftbukkit.v1_19_R1.CraftServer;
 
 import dev.imprex.orebfuscator.cache.AbstractRegionFileCache;
 import dev.imprex.orebfuscator.config.api.CacheConfig;
 import dev.imprex.orebfuscator.util.ChunkCacheKey;
+import net.minecraft.server.dedicated.DedicatedServer;
 import net.minecraft.world.level.ChunkPos;
 import net.minecraft.world.level.chunk.storage.RegionFile;
 import net.minecraft.world.level.chunk.storage.RegionFileVersion;
@@ -23,7 +23,7 @@ public class RegionFileCache extends AbstractRegionFileCache<RegionFile> {
 
   @Override
   protected RegionFile createRegionFile(Path path) throws IOException {
-    boolean isSyncChunkWrites = ((CraftServer) Bukkit.getServer()).getServer().forceSynchronousWrites();
+    boolean isSyncChunkWrites = serverHandle(Bukkit.getServer(), DedicatedServer.class).forceSynchronousWrites();
     return new RegionFile(path, path.getParent(), RegionFileVersion.VERSION_NONE, isSyncChunkWrites);
   }
 

--- a/orebfuscator-nms/orebfuscator-nms-v1_19_R2/src/main/java/net/imprex/orebfuscator/nms/v1_19_R2/RegionFileCache.java
+++ b/orebfuscator-nms/orebfuscator-nms-v1_19_R2/src/main/java/net/imprex/orebfuscator/nms/v1_19_R2/RegionFileCache.java
@@ -6,11 +6,11 @@ import java.io.IOException;
 import java.nio.file.Path;
 
 import org.bukkit.Bukkit;
-import org.bukkit.craftbukkit.v1_19_R2.CraftServer;
 
 import dev.imprex.orebfuscator.cache.AbstractRegionFileCache;
 import dev.imprex.orebfuscator.config.api.CacheConfig;
 import dev.imprex.orebfuscator.util.ChunkCacheKey;
+import net.minecraft.server.dedicated.DedicatedServer;
 import net.minecraft.world.level.ChunkPos;
 import net.minecraft.world.level.chunk.storage.RegionFile;
 import net.minecraft.world.level.chunk.storage.RegionFileVersion;
@@ -23,7 +23,7 @@ public class RegionFileCache extends AbstractRegionFileCache<RegionFile> {
 
   @Override
   protected RegionFile createRegionFile(Path path) throws IOException {
-    boolean isSyncChunkWrites = ((CraftServer) Bukkit.getServer()).getServer().forceSynchronousWrites();
+    boolean isSyncChunkWrites = serverHandle(Bukkit.getServer(), DedicatedServer.class).forceSynchronousWrites();
     return new RegionFile(path, path.getParent(), RegionFileVersion.VERSION_NONE, isSyncChunkWrites);
   }
 

--- a/orebfuscator-nms/orebfuscator-nms-v1_19_R3/src/main/java/net/imprex/orebfuscator/nms/v1_19_R3/RegionFileCache.java
+++ b/orebfuscator-nms/orebfuscator-nms-v1_19_R3/src/main/java/net/imprex/orebfuscator/nms/v1_19_R3/RegionFileCache.java
@@ -6,11 +6,11 @@ import java.io.IOException;
 import java.nio.file.Path;
 
 import org.bukkit.Bukkit;
-import org.bukkit.craftbukkit.v1_19_R3.CraftServer;
 
 import dev.imprex.orebfuscator.cache.AbstractRegionFileCache;
 import dev.imprex.orebfuscator.config.api.CacheConfig;
 import dev.imprex.orebfuscator.util.ChunkCacheKey;
+import net.minecraft.server.dedicated.DedicatedServer;
 import net.minecraft.world.level.ChunkPos;
 import net.minecraft.world.level.chunk.storage.RegionFile;
 import net.minecraft.world.level.chunk.storage.RegionFileVersion;
@@ -23,7 +23,7 @@ public class RegionFileCache extends AbstractRegionFileCache<RegionFile> {
 
   @Override
   protected RegionFile createRegionFile(Path path) throws IOException {
-    boolean isSyncChunkWrites = ((CraftServer) Bukkit.getServer()).getServer().forceSynchronousWrites();
+    boolean isSyncChunkWrites = serverHandle(Bukkit.getServer(), DedicatedServer.class).forceSynchronousWrites();
     return new RegionFile(path, path.getParent(), RegionFileVersion.VERSION_NONE, isSyncChunkWrites);
   }
 

--- a/orebfuscator-nms/orebfuscator-nms-v1_20_R1/src/main/java/net/imprex/orebfuscator/nms/v1_20_R1/RegionFileCache.java
+++ b/orebfuscator-nms/orebfuscator-nms-v1_20_R1/src/main/java/net/imprex/orebfuscator/nms/v1_20_R1/RegionFileCache.java
@@ -6,11 +6,11 @@ import java.io.IOException;
 import java.nio.file.Path;
 
 import org.bukkit.Bukkit;
-import org.bukkit.craftbukkit.v1_20_R1.CraftServer;
 
 import dev.imprex.orebfuscator.cache.AbstractRegionFileCache;
 import dev.imprex.orebfuscator.config.api.CacheConfig;
 import dev.imprex.orebfuscator.util.ChunkCacheKey;
+import net.minecraft.server.dedicated.DedicatedServer;
 import net.minecraft.world.level.ChunkPos;
 import net.minecraft.world.level.chunk.storage.RegionFile;
 import net.minecraft.world.level.chunk.storage.RegionFileVersion;
@@ -23,7 +23,7 @@ public class RegionFileCache extends AbstractRegionFileCache<RegionFile> {
 
   @Override
   protected RegionFile createRegionFile(Path path) throws IOException {
-    boolean isSyncChunkWrites = ((CraftServer) Bukkit.getServer()).getServer().forceSynchronousWrites();
+    boolean isSyncChunkWrites = serverHandle(Bukkit.getServer(), DedicatedServer.class).forceSynchronousWrites();
     return new RegionFile(path, path.getParent(), RegionFileVersion.VERSION_NONE, isSyncChunkWrites);
   }
 

--- a/orebfuscator-nms/orebfuscator-nms-v1_20_R2/src/main/java/net/imprex/orebfuscator/nms/v1_20_R2/RegionFileCache.java
+++ b/orebfuscator-nms/orebfuscator-nms-v1_20_R2/src/main/java/net/imprex/orebfuscator/nms/v1_20_R2/RegionFileCache.java
@@ -6,11 +6,11 @@ import java.io.IOException;
 import java.nio.file.Path;
 
 import org.bukkit.Bukkit;
-import org.bukkit.craftbukkit.v1_20_R2.CraftServer;
 
 import dev.imprex.orebfuscator.cache.AbstractRegionFileCache;
 import dev.imprex.orebfuscator.config.api.CacheConfig;
 import dev.imprex.orebfuscator.util.ChunkCacheKey;
+import net.minecraft.server.dedicated.DedicatedServer;
 import net.minecraft.world.level.ChunkPos;
 import net.minecraft.world.level.chunk.storage.RegionFile;
 import net.minecraft.world.level.chunk.storage.RegionFileVersion;
@@ -23,7 +23,7 @@ public class RegionFileCache extends AbstractRegionFileCache<RegionFile> {
 
   @Override
   protected RegionFile createRegionFile(Path path) throws IOException {
-    boolean isSyncChunkWrites = ((CraftServer) Bukkit.getServer()).getServer().forceSynchronousWrites();
+    boolean isSyncChunkWrites = serverHandle(Bukkit.getServer(), DedicatedServer.class).forceSynchronousWrites();
     return new RegionFile(path, path.getParent(), RegionFileVersion.VERSION_NONE, isSyncChunkWrites);
   }
 

--- a/orebfuscator-nms/orebfuscator-nms-v1_20_R3/src/main/java/net/imprex/orebfuscator/nms/v1_20_R3/RegionFileCache.java
+++ b/orebfuscator-nms/orebfuscator-nms-v1_20_R3/src/main/java/net/imprex/orebfuscator/nms/v1_20_R3/RegionFileCache.java
@@ -6,11 +6,11 @@ import java.io.IOException;
 import java.nio.file.Path;
 
 import org.bukkit.Bukkit;
-import org.bukkit.craftbukkit.v1_20_R3.CraftServer;
 
 import dev.imprex.orebfuscator.cache.AbstractRegionFileCache;
 import dev.imprex.orebfuscator.config.api.CacheConfig;
 import dev.imprex.orebfuscator.util.ChunkCacheKey;
+import net.minecraft.server.dedicated.DedicatedServer;
 import net.minecraft.world.level.ChunkPos;
 import net.minecraft.world.level.chunk.storage.RegionFile;
 import net.minecraft.world.level.chunk.storage.RegionFileVersion;
@@ -23,7 +23,7 @@ public class RegionFileCache extends AbstractRegionFileCache<RegionFile> {
 
   @Override
   protected RegionFile createRegionFile(Path path) throws IOException {
-    boolean isSyncChunkWrites = ((CraftServer) Bukkit.getServer()).getServer().forceSynchronousWrites();
+    boolean isSyncChunkWrites = serverHandle(Bukkit.getServer(), DedicatedServer.class).forceSynchronousWrites();
     return new RegionFile(path, path.getParent(), RegionFileVersion.VERSION_NONE, isSyncChunkWrites);
   }
 

--- a/orebfuscator-nms/orebfuscator-nms-v1_20_R4/src/main/java/net/imprex/orebfuscator/nms/v1_20_R4/RegionFileCache.java
+++ b/orebfuscator-nms/orebfuscator-nms-v1_20_R4/src/main/java/net/imprex/orebfuscator/nms/v1_20_R4/RegionFileCache.java
@@ -6,11 +6,11 @@ import java.io.IOException;
 import java.nio.file.Path;
 
 import org.bukkit.Bukkit;
-import org.bukkit.craftbukkit.v1_20_R4.CraftServer;
 
 import dev.imprex.orebfuscator.cache.AbstractRegionFileCache;
 import dev.imprex.orebfuscator.config.api.CacheConfig;
 import dev.imprex.orebfuscator.util.ChunkCacheKey;
+import net.minecraft.server.dedicated.DedicatedServer;
 import net.minecraft.world.level.ChunkPos;
 import net.minecraft.world.level.chunk.storage.RegionFile;
 import net.minecraft.world.level.chunk.storage.RegionFileVersion;
@@ -23,7 +23,7 @@ public class RegionFileCache extends AbstractRegionFileCache<RegionFile> {
 
   @Override
   protected RegionFile createRegionFile(Path path) throws IOException {
-    boolean isSyncChunkWrites = ((CraftServer) Bukkit.getServer()).getServer().forceSynchronousWrites();
+    boolean isSyncChunkWrites = serverHandle(Bukkit.getServer(), DedicatedServer.class).forceSynchronousWrites();
     return new RegionFile(null, path, path.getParent(), RegionFileVersion.VERSION_NONE, isSyncChunkWrites);
   }
 

--- a/orebfuscator-nms/orebfuscator-nms-v1_21_R1/src/main/java/net/imprex/orebfuscator/nms/v1_21_R1/RegionFileCache.java
+++ b/orebfuscator-nms/orebfuscator-nms-v1_21_R1/src/main/java/net/imprex/orebfuscator/nms/v1_21_R1/RegionFileCache.java
@@ -6,11 +6,11 @@ import java.io.IOException;
 import java.nio.file.Path;
 
 import org.bukkit.Bukkit;
-import org.bukkit.craftbukkit.v1_21_R1.CraftServer;
 
 import dev.imprex.orebfuscator.cache.AbstractRegionFileCache;
 import dev.imprex.orebfuscator.config.api.CacheConfig;
 import dev.imprex.orebfuscator.util.ChunkCacheKey;
+import net.minecraft.server.dedicated.DedicatedServer;
 import net.minecraft.world.level.ChunkPos;
 import net.minecraft.world.level.chunk.storage.RegionFile;
 import net.minecraft.world.level.chunk.storage.RegionFileVersion;
@@ -23,7 +23,7 @@ public class RegionFileCache extends AbstractRegionFileCache<RegionFile> {
 
   @Override
   protected RegionFile createRegionFile(Path path) throws IOException {
-    boolean isSyncChunkWrites = ((CraftServer) Bukkit.getServer()).getServer().forceSynchronousWrites();
+    boolean isSyncChunkWrites = serverHandle(Bukkit.getServer(), DedicatedServer.class).forceSynchronousWrites();
     return new RegionFile(null, path, path.getParent(), RegionFileVersion.VERSION_NONE, isSyncChunkWrites);
   }
 

--- a/orebfuscator-nms/orebfuscator-nms-v1_21_R2/src/main/java/net/imprex/orebfuscator/nms/v1_21_R2/RegionFileCache.java
+++ b/orebfuscator-nms/orebfuscator-nms-v1_21_R2/src/main/java/net/imprex/orebfuscator/nms/v1_21_R2/RegionFileCache.java
@@ -6,11 +6,11 @@ import java.io.IOException;
 import java.nio.file.Path;
 
 import org.bukkit.Bukkit;
-import org.bukkit.craftbukkit.v1_21_R2.CraftServer;
 
 import dev.imprex.orebfuscator.cache.AbstractRegionFileCache;
 import dev.imprex.orebfuscator.config.api.CacheConfig;
 import dev.imprex.orebfuscator.util.ChunkCacheKey;
+import net.minecraft.server.dedicated.DedicatedServer;
 import net.minecraft.world.level.ChunkPos;
 import net.minecraft.world.level.chunk.storage.RegionFile;
 import net.minecraft.world.level.chunk.storage.RegionFileVersion;
@@ -23,7 +23,7 @@ public class RegionFileCache extends AbstractRegionFileCache<RegionFile> {
 
   @Override
   protected RegionFile createRegionFile(Path path) throws IOException {
-    boolean isSyncChunkWrites = ((CraftServer) Bukkit.getServer()).getServer().forceSynchronousWrites();
+    boolean isSyncChunkWrites = serverHandle(Bukkit.getServer(), DedicatedServer.class).forceSynchronousWrites();
     return new RegionFile(null, path, path.getParent(), RegionFileVersion.VERSION_NONE, isSyncChunkWrites);
   }
 

--- a/orebfuscator-nms/orebfuscator-nms-v1_21_R3/src/main/java/net/imprex/orebfuscator/nms/v1_21_R3/RegionFileCache.java
+++ b/orebfuscator-nms/orebfuscator-nms-v1_21_R3/src/main/java/net/imprex/orebfuscator/nms/v1_21_R3/RegionFileCache.java
@@ -6,11 +6,11 @@ import java.io.IOException;
 import java.nio.file.Path;
 
 import org.bukkit.Bukkit;
-import org.bukkit.craftbukkit.v1_21_R3.CraftServer;
 
 import dev.imprex.orebfuscator.cache.AbstractRegionFileCache;
 import dev.imprex.orebfuscator.config.api.CacheConfig;
 import dev.imprex.orebfuscator.util.ChunkCacheKey;
+import net.minecraft.server.dedicated.DedicatedServer;
 import net.minecraft.world.level.ChunkPos;
 import net.minecraft.world.level.chunk.storage.RegionFile;
 import net.minecraft.world.level.chunk.storage.RegionFileVersion;
@@ -23,7 +23,7 @@ public class RegionFileCache extends AbstractRegionFileCache<RegionFile> {
 
   @Override
   protected RegionFile createRegionFile(Path path) throws IOException {
-    boolean isSyncChunkWrites = ((CraftServer) Bukkit.getServer()).getServer().forceSynchronousWrites();
+    boolean isSyncChunkWrites = serverHandle(Bukkit.getServer(), DedicatedServer.class).forceSynchronousWrites();
     return new RegionFile(null, path, path.getParent(), RegionFileVersion.VERSION_NONE, isSyncChunkWrites);
   }
 

--- a/orebfuscator-nms/orebfuscator-nms-v1_21_R4/src/main/java/net/imprex/orebfuscator/nms/v1_21_R4/RegionFileCache.java
+++ b/orebfuscator-nms/orebfuscator-nms-v1_21_R4/src/main/java/net/imprex/orebfuscator/nms/v1_21_R4/RegionFileCache.java
@@ -6,11 +6,11 @@ import java.io.IOException;
 import java.nio.file.Path;
 
 import org.bukkit.Bukkit;
-import org.bukkit.craftbukkit.v1_21_R4.CraftServer;
 
 import dev.imprex.orebfuscator.cache.AbstractRegionFileCache;
 import dev.imprex.orebfuscator.config.api.CacheConfig;
 import dev.imprex.orebfuscator.util.ChunkCacheKey;
+import net.minecraft.server.dedicated.DedicatedServer;
 import net.minecraft.world.level.ChunkPos;
 import net.minecraft.world.level.chunk.storage.RegionFile;
 import net.minecraft.world.level.chunk.storage.RegionFileVersion;
@@ -23,7 +23,7 @@ public class RegionFileCache extends AbstractRegionFileCache<RegionFile> {
 
   @Override
   protected RegionFile createRegionFile(Path path) throws IOException {
-    boolean isSyncChunkWrites = ((CraftServer) Bukkit.getServer()).getServer().forceSynchronousWrites();
+    boolean isSyncChunkWrites = serverHandle(Bukkit.getServer(), DedicatedServer.class).forceSynchronousWrites();
     return new RegionFile(null, path, path.getParent(), RegionFileVersion.VERSION_NONE, isSyncChunkWrites);
   }
 

--- a/orebfuscator-nms/orebfuscator-nms-v1_21_R5/src/main/java/net/imprex/orebfuscator/nms/v1_21_R5/RegionFileCache.java
+++ b/orebfuscator-nms/orebfuscator-nms-v1_21_R5/src/main/java/net/imprex/orebfuscator/nms/v1_21_R5/RegionFileCache.java
@@ -6,11 +6,11 @@ import java.io.IOException;
 import java.nio.file.Path;
 
 import org.bukkit.Bukkit;
-import org.bukkit.craftbukkit.v1_21_R5.CraftServer;
 
 import dev.imprex.orebfuscator.cache.AbstractRegionFileCache;
 import dev.imprex.orebfuscator.config.api.CacheConfig;
 import dev.imprex.orebfuscator.util.ChunkCacheKey;
+import net.minecraft.server.dedicated.DedicatedServer;
 import net.minecraft.world.level.ChunkPos;
 import net.minecraft.world.level.chunk.storage.RegionFile;
 import net.minecraft.world.level.chunk.storage.RegionFileVersion;
@@ -23,7 +23,7 @@ public class RegionFileCache extends AbstractRegionFileCache<RegionFile> {
 
   @Override
   protected RegionFile createRegionFile(Path path) throws IOException {
-    boolean isSyncChunkWrites = ((CraftServer) Bukkit.getServer()).getServer().forceSynchronousWrites();
+    boolean isSyncChunkWrites = serverHandle(Bukkit.getServer(), DedicatedServer.class).forceSynchronousWrites();
     return new RegionFile(null, path, path.getParent(), RegionFileVersion.VERSION_NONE, isSyncChunkWrites);
   }
 

--- a/orebfuscator-nms/orebfuscator-nms-v1_21_R6/src/main/java/net/imprex/orebfuscator/nms/v1_21_R6/RegionFileCache.java
+++ b/orebfuscator-nms/orebfuscator-nms-v1_21_R6/src/main/java/net/imprex/orebfuscator/nms/v1_21_R6/RegionFileCache.java
@@ -6,11 +6,11 @@ import java.io.IOException;
 import java.nio.file.Path;
 
 import org.bukkit.Bukkit;
-import org.bukkit.craftbukkit.v1_21_R6.CraftServer;
 
 import dev.imprex.orebfuscator.cache.AbstractRegionFileCache;
 import dev.imprex.orebfuscator.config.api.CacheConfig;
 import dev.imprex.orebfuscator.util.ChunkCacheKey;
+import net.minecraft.server.dedicated.DedicatedServer;
 import net.minecraft.world.level.ChunkPos;
 import net.minecraft.world.level.chunk.storage.RegionFile;
 import net.minecraft.world.level.chunk.storage.RegionFileVersion;
@@ -23,7 +23,7 @@ public class RegionFileCache extends AbstractRegionFileCache<RegionFile> {
 
   @Override
   protected RegionFile createRegionFile(Path path) throws IOException {
-    boolean isSyncChunkWrites = ((CraftServer) Bukkit.getServer()).getServer().forceSynchronousWrites();
+    boolean isSyncChunkWrites = serverHandle(Bukkit.getServer(), DedicatedServer.class).forceSynchronousWrites();
     return new RegionFile(null, path, path.getParent(), RegionFileVersion.VERSION_NONE, isSyncChunkWrites);
   }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
We recently switched to mojang mappings on paper and I accidentally forgot to remove the CraftServer reference inside the region file cache. 

## Related Issue
closes #454 

## How Has This Been Tested?
Successfully tested with latest 1.21.9 spigot and paper build.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
