### PR TITLE
Fix `/orebfuscator dump` command on spigot

### DIFF
--- a/.github/workflows/buildtools.sh
+++ b/.github/workflows/buildtools.sh
@@ -24,8 +24,6 @@ checkVersion () {
   fi
 }
 
-checkVersion "1.16.1" "8"
-checkVersion "1.16.3" "8"
 checkVersion "1.16.5" "8"
 checkVersion "1.17.1" "17"
 checkVersion "1.18.1" "17"

--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ Orebfuscator empowers server owners to protect their server from X-Ray Clients a
 
 ### Requirements
 * Java 17 or higher
-* Spigot, Paper, Folia or compatible forks (1.16 or newer)
-* [ProtocolLib](https://www.spigotmc.org/resources/protocollib.1997) 5.2.0 or later
+* Spigot, Paper, Folia or compatible forks (1.16.5 or newer)
+* [ProtocolLib](https://www.spigotmc.org/resources/protocollib.1997) 5.4.0 or later
 
 ### Installation
 1. Download [ProtocolLib](https://github.com/dmulloy2/ProtocolLib/releases)
@@ -25,6 +25,50 @@ Orebfuscator empowers server owners to protect their server from X-Ray Clients a
 4. Start your server and [configure Orebfuscator](https://github.com/Imprex-Development/Orebfuscator/wiki/Config) to your liking
 
 Still having trouble getting Orebfuscator to run check out our [common issues](https://github.com/Imprex-Development/Orebfuscator/wiki/Common-Issues).
+
+## Version Support Policy
+
+### Supported Minecraft Versions
+
+Orebfuscator follows a **rolling support window** for Minecraft versions.
+
+Starting with **Minecraft 27.x**, Orebfuscator will officially support **only the two most recent major Minecraft releases**.
+
+Example:
+
+| Latest Minecraft Version | Supported Versions |
+|--------------------------|--------------------|
+| 27.x                     | 27.x and 26.x      |
+| 28.x                     | 28.x and 27.x      |
+
+When a new major Minecraft version is released, the oldest supported version will be dropped in a future Orebfuscator release.
+
+Older versions may still work but are **not guaranteed to receive fixes or compatibility updates**.
+
+### Testing Policy
+
+Testing policy differs depending on the Minecraft release cycle.
+
+**Until Minecraft 27.x**
+
+Each Orebfuscator release is tested against all supported Minecraft versions on PaperMC and Spigot with the following exceptions:
+
+- 1.17.x
+- 1.18.x
+- 1.19.x
+
+The following versions are still included in testing:
+
+- 1.16.5
+- 1.20.x and newer supported releases
+
+**After Minecraft 27.x**
+
+Testing will focus on the **latest Minecraft major version only** for each Orebfuscator release.
+
+Other versions within the support window may remain compatible but will not necessarily be tested for every release.
+
+Servers running untested versions may still function, but issues specific to those versions may not be prioritized.
 
 ### Legacy support
 For compatibility with Java 11 or Minecraft 1.9.4 and later, you can use any legacy release prior to version 5.5.0. Please note that these legacy releases will no longer receive regular support or updates. However, they may receive critical security and vulnerability patches if necessary.
@@ -52,32 +96,34 @@ To include the API in your Maven project, add the following configuration to you
 </dependencies>
 ```
 
-## License:
+## License
 
-Completely rewritten by Imprex-Development to support v1.14 and higher Minecraft version's; these portions as permissible:
-Copyright (C) 2020-2025 by Imprex-Development. All rights reserved.
+### Modifications
 
-Released under the same license as original.
+Copyright (C) 2020–2026 Imprex-Development  
+Completely rewritten to support Minecraft v1.14 and higher.
 
-Significantly reworked by Aleksey_Terzi to support v1.9 Minecraft; these portions as permissible:
-Copyright (C) 2016 by Aleksey_Terzi. All rights reserved.
+Copyright (C) 2016 Aleksey_Terzi  
+Significant rework to support Minecraft v1.9.
 
-Released under the same license as original.
+These modifications are distributed under the same license as the original work.
 
-#### Original Copyright and License:
+---
 
-Copyright (C) 2011-2015 lishid.  All rights reserved.
+### Original Work
 
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation,  version 3.
+Copyright (C) 2011–2015 lishid
 
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+This program is free software: you can redistribute it and/or modify  
+it under the terms of the GNU General Public License as published by  
+the Free Software Foundation, version 3.
+
+This program is distributed in the hope that it will be useful,  
+but WITHOUT ANY WARRANTY; without even the implied warranty of  
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the  
 GNU General Public License for more details.
 
-You should have received a copy of the GNU General Public License
-along with this program. If not, see <http://www.gnu.org/licenses/>.
+You should have received a copy of the GNU General Public License  
+along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-See the LICENSE file.
+See the `LICENSE` file for the full license text.

--- a/orebfuscator-core/pom.xml
+++ b/orebfuscator-core/pom.xml
@@ -34,30 +34,35 @@
       <artifactId>guava</artifactId>
       <version>${dependency.guava.version}</version>
       <scope>compile</scope>
+      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
       <version>${dependency.gson.version}</version>
-      <scope>provided</scope>
+      <scope>compile</scope>
+      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>org.yaml</groupId>
       <artifactId>snakeyaml</artifactId>
       <version>${dependency.snakeyaml.version}</version>
       <scope>compile</scope>
+      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>org.joml</groupId>
       <artifactId>joml</artifactId>
       <version>${dependency.joml.version}</version>
-      <scope>provided</scope>
+      <scope>compile</scope>
+      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>at.yawk.lz4</groupId>
       <artifactId>lz4-java</artifactId>
       <version>${dependency.lz4.version}</version>
-      <scope>provided</scope>
+      <scope>compile</scope>
+      <optional>true</optional>
     </dependency>
   </dependencies>
 
@@ -67,10 +72,27 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
         <configuration>
+          <minimizeJar>true</minimizeJar>
+          <filters>
+            <filter>
+              <artifact>*:lz4-java</artifact>
+              <includes>
+                <include>**</include>
+              </includes>
+            </filter>
+          </filters>
           <relocations>
             <relocation>
-              <pattern>com.google.common</pattern>
-              <shadedPattern>dev.imprex.shaded.com.google.common</shadedPattern>
+              <pattern>com.google</pattern>
+              <shadedPattern>dev.imprex.shaded.com.google</shadedPattern>
+            </relocation>
+            <relocation>
+              <pattern>net.jpountz</pattern>
+              <shadedPattern>dev.imprex.shaded.net.jpountz</shadedPattern>
+            </relocation>
+            <relocation>
+              <pattern>org.joml</pattern>
+              <shadedPattern>dev.imprex.shaded.org.joml</shadedPattern>
             </relocation>
             <relocation>
               <pattern>org.yaml.snakeyaml</pattern>

--- a/orebfuscator-core/src/main/java/dev/imprex/orebfuscator/OrebfuscatorDumpFile.java
+++ b/orebfuscator-core/src/main/java/dev/imprex/orebfuscator/OrebfuscatorDumpFile.java
@@ -37,6 +37,7 @@ public class OrebfuscatorDumpFile extends ConfigurationSection {
   private static final DateTimeFormatter TIME_FORMAT = DateTimeFormatter.ISO_OFFSET_DATE_TIME;
 
   private static final Gson GSON = new GsonBuilder().setPrettyPrinting()
+      .disableHtmlEscaping()
       .registerTypeAdapter(OrebfuscatorDumpFile.class, new Json())
       .registerTypeAdapter(ConfigurationSection.class, new Json())
       .create();

--- a/orebfuscator-core/src/main/java/dev/imprex/orebfuscator/OrebfuscatorDumpFile.java
+++ b/orebfuscator-core/src/main/java/dev/imprex/orebfuscator/OrebfuscatorDumpFile.java
@@ -9,8 +9,6 @@ import com.google.gson.JsonObject;
 import com.google.gson.JsonPrimitive;
 import com.google.gson.JsonSerializationContext;
 import com.google.gson.JsonSerializer;
-import com.google.gson.internal.Streams;
-import com.google.gson.stream.JsonWriter;
 import dev.imprex.orebfuscator.config.yaml.ConfigurationSection;
 import dev.imprex.orebfuscator.interop.OrebfuscatorCore;
 import dev.imprex.orebfuscator.interop.WorldAccessor;
@@ -59,6 +57,8 @@ public class OrebfuscatorDumpFile extends ConfigurationSection {
 
     set("versions.java", JavaVersion.get());
     set("versions.orebfuscator", orebfuscator.orebfuscatorVersion().toString());
+
+    orebfuscator.systemMonitor().dump(createSection("system"));
 
     var statistics = createSection("statistics");
     orebfuscator.statisticsRegistry().entries().stream()

--- a/orebfuscator-core/src/main/java/dev/imprex/orebfuscator/SystemMonitor.java
+++ b/orebfuscator-core/src/main/java/dev/imprex/orebfuscator/SystemMonitor.java
@@ -56,6 +56,7 @@ public class SystemMonitor implements Runnable {
     }
 
     var runtime = Runtime.getRuntime();
+    section.set("cpu.core", runtime.availableProcessors());
     section.set("memory.process.total", runtime.totalMemory());
     section.set("memory.process.free", runtime.freeMemory());
 

--- a/orebfuscator-core/src/main/java/dev/imprex/orebfuscator/SystemMonitor.java
+++ b/orebfuscator-core/src/main/java/dev/imprex/orebfuscator/SystemMonitor.java
@@ -1,0 +1,101 @@
+package dev.imprex.orebfuscator;
+
+import dev.imprex.orebfuscator.config.yaml.ConfigurationSection;
+import dev.imprex.orebfuscator.interop.OrebfuscatorCore;
+import dev.imprex.orebfuscator.util.RollingAverage;
+import java.lang.management.ManagementFactory;
+import java.lang.management.RuntimeMXBean;
+import java.util.concurrent.TimeUnit;
+import javax.management.JMX;
+import javax.management.MBeanServer;
+import javax.management.ObjectName;
+import org.jspecify.annotations.Nullable;
+
+public class SystemMonitor implements Runnable {
+
+  private static @Nullable OperatingSystemMXBeanProxy tryCreateOsBeanProxy() {
+    try {
+      MBeanServer beanServer = ManagementFactory.getPlatformMBeanServer();
+      ObjectName beanName = ObjectName.getInstance(ManagementFactory.OPERATING_SYSTEM_MXBEAN_NAME);
+      return JMX.newMXBeanProxy(beanServer, beanName, OperatingSystemMXBeanProxy.class);
+    } catch (Exception | LinkageError e) {
+      return null;
+    }
+  }
+
+  private final @Nullable OperatingSystemMXBeanProxy osBean;
+
+  private final RollingAverage system10sec = new RollingAverage(10);
+  private final RollingAverage system1min = new RollingAverage(60);
+  private final RollingAverage system15min = new RollingAverage(60 * 15);
+  private final RollingAverage process10sec = new RollingAverage(10);
+  private final RollingAverage process1min = new RollingAverage(60);
+  private final RollingAverage process15min = new RollingAverage(60 * 15);
+
+  private final RollingAverage[] system = new RollingAverage[]{system10sec, system1min, system15min};
+  private final RollingAverage[] process = new RollingAverage[]{process10sec, process1min, process15min};
+
+  public SystemMonitor(OrebfuscatorCore orebfuscator) {
+    this.osBean = tryCreateOsBeanProxy();
+    if (this.osBean != null) {
+      orebfuscator.executor().scheduleAtFixedRate(this, 0, 1, TimeUnit.SECONDS);
+    }
+  }
+
+  public void dump(ConfigurationSection section) {
+    if (this.osBean != null) {
+      section.set("cpu.system", "%.1f%% / %.1f%% / %.1f%%".formatted(
+          system10sec.average() * 100, system1min.average() * 100, system15min.average() * 100));
+      section.set("cpu.process", "%.1f%% / %.1f%% / %.1f%%".formatted(
+          process10sec.average() * 100, process1min.average() * 100, process15min.average() * 100));
+
+      section.set("memory.physical.total", this.osBean.getTotalMemorySize());
+      section.set("memory.physical.free", this.osBean.getFreeMemorySize());
+      section.set("memory.swap.total", this.osBean.getTotalSwapSpaceSize());
+      section.set("memory.swap.free", this.osBean.getFreeSwapSpaceSize());
+    }
+
+    var runtime = Runtime.getRuntime();
+    section.set("memory.process.total", runtime.totalMemory());
+    section.set("memory.process.free", runtime.freeMemory());
+
+    section.set("java.version", System.getProperty("java.version", "unknown"));
+    section.set("java.vendor.name", System.getProperty("java.vendor", "unknown"));
+    section.set("java.vendor.version", System.getProperty("java.vendor.version", "unknown"));
+
+    RuntimeMXBean runtimeBean = ManagementFactory.getRuntimeMXBean();
+    section.set("jvm.name", System.getProperty("java.vm.name", "unknown"));
+    section.set("jvm.vendor", System.getProperty("java.vm.vendor", "unknown"));
+    section.set("jvm.version", System.getProperty("java.vm.version", "unknown"));
+    section.set("jvm.args", String.join(" ", runtimeBean.getInputArguments()));
+  }
+
+  @Override
+  public void run() {
+    assert this.osBean != null;
+
+    double cpuLoad = this.osBean.getCpuLoad();
+    if (cpuLoad >= 0) {
+      for (RollingAverage average : this.system) {
+        average.add(cpuLoad);
+      }
+    }
+
+    double processCpuLoad = this.osBean.getProcessCpuLoad();
+    if (processCpuLoad >= 0) {
+      for (RollingAverage average : this.process) {
+        average.add(cpuLoad);
+      }
+    }
+  }
+
+
+  public interface OperatingSystemMXBeanProxy {
+    long getTotalSwapSpaceSize();
+    long getFreeSwapSpaceSize();
+    long getTotalMemorySize();
+    long getFreeMemorySize();
+    double getCpuLoad();
+    double getProcessCpuLoad();
+  }
+}

--- a/orebfuscator-core/src/main/java/dev/imprex/orebfuscator/config/OrebfuscatorObfuscationConfig.java
+++ b/orebfuscator-core/src/main/java/dev/imprex/orebfuscator/config/OrebfuscatorObfuscationConfig.java
@@ -1,17 +1,15 @@
 package dev.imprex.orebfuscator.config;
 
-import dev.imprex.orebfuscator.config.components.WeightedBlockList;
-import java.util.ArrayList;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Set;
-import com.google.gson.JsonObject;
 import dev.imprex.orebfuscator.config.api.ObfuscationConfig;
 import dev.imprex.orebfuscator.config.components.BlockParser;
 import dev.imprex.orebfuscator.config.components.ConfigBlockValue;
 import dev.imprex.orebfuscator.config.context.ConfigMessage;
 import dev.imprex.orebfuscator.config.context.ConfigParsingContext;
 import dev.imprex.orebfuscator.config.yaml.ConfigurationSection;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
 import org.jspecify.annotations.NullMarked;
 
 @NullMarked

--- a/orebfuscator-core/src/main/java/dev/imprex/orebfuscator/config/OrebfuscatorProximityConfig.java
+++ b/orebfuscator-core/src/main/java/dev/imprex/orebfuscator/config/OrebfuscatorProximityConfig.java
@@ -1,11 +1,5 @@
 package dev.imprex.orebfuscator.config;
 
-import java.util.HashSet;
-import java.util.LinkedHashMap;
-import java.util.Map;
-import java.util.Set;
-import org.joml.Matrix4f;
-import com.google.gson.JsonObject;
 import dev.imprex.orebfuscator.config.api.BlockFlags;
 import dev.imprex.orebfuscator.config.api.ProximityConfig;
 import dev.imprex.orebfuscator.config.components.BlockParser;
@@ -15,6 +9,11 @@ import dev.imprex.orebfuscator.config.context.ConfigMessage;
 import dev.imprex.orebfuscator.config.context.ConfigParsingContext;
 import dev.imprex.orebfuscator.config.yaml.ConfigurationSection;
 import dev.imprex.orebfuscator.util.BlockProperties;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+import org.joml.Matrix4f;
 import org.jspecify.annotations.NullMarked;
 
 @NullMarked

--- a/orebfuscator-core/src/main/java/dev/imprex/orebfuscator/config/components/ConfigBlockValue.java
+++ b/orebfuscator-core/src/main/java/dev/imprex/orebfuscator/config/components/ConfigBlockValue.java
@@ -1,16 +1,12 @@
 package dev.imprex.orebfuscator.config.components;
 
 import dev.imprex.orebfuscator.config.yaml.ConfigurationSection;
+import dev.imprex.orebfuscator.util.BlockProperties;
+import dev.imprex.orebfuscator.util.BlockTag;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Objects;
 import java.util.Set;
-import com.google.gson.JsonArray;
-import com.google.gson.JsonElement;
-import com.google.gson.JsonObject;
-import com.google.gson.JsonPrimitive;
-import dev.imprex.orebfuscator.util.BlockProperties;
-import dev.imprex.orebfuscator.util.BlockTag;
 import org.jspecify.annotations.NullMarked;
 
 @NullMarked

--- a/orebfuscator-core/src/main/java/dev/imprex/orebfuscator/interop/OrebfuscatorCore.java
+++ b/orebfuscator-core/src/main/java/dev/imprex/orebfuscator/interop/OrebfuscatorCore.java
@@ -1,7 +1,7 @@
 package dev.imprex.orebfuscator.interop;
 
+import dev.imprex.orebfuscator.SystemMonitor;
 import dev.imprex.orebfuscator.statistics.StatisticsRegistry;
-import dev.imprex.orebfuscator.util.Version;
 import org.jspecify.annotations.NullMarked;
 import dev.imprex.orebfuscator.cache.ObfuscationCache;
 import dev.imprex.orebfuscator.chunk.ChunkFactory;
@@ -19,6 +19,8 @@ public interface OrebfuscatorCore extends ServerAccessor {
   String name();
 
   OrebfuscatorExecutor executor();
+
+  SystemMonitor systemMonitor();
 
   StatisticsRegistry statisticsRegistry();
 

--- a/orebfuscator-core/src/main/java/dev/imprex/orebfuscator/statistics/StatisticsRegistry.java
+++ b/orebfuscator-core/src/main/java/dev/imprex/orebfuscator/statistics/StatisticsRegistry.java
@@ -1,16 +1,13 @@
 package dev.imprex.orebfuscator.statistics;
 
-import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 import java.util.StringJoiner;
 import java.util.stream.Collectors;
-import com.google.gson.JsonObject;
 
 public class StatisticsRegistry {
 

--- a/orebfuscator-core/src/main/resources/config/config-1.16.0.yml
+++ b/orebfuscator-core/src/main/resources/config/config-1.16.0.yml
@@ -20,7 +20,7 @@ cache:
     maximumSize: 32768
     expireAfterAccess: 60000
   diskCache:
-    enabled: true
+    enabled: false
     directory: orebfuscator_cache
     maximumOpenFiles: 256
     deleteFilesAfterAccess: 172800000

--- a/orebfuscator-core/src/main/resources/config/config-1.17.0.yml
+++ b/orebfuscator-core/src/main/resources/config/config-1.17.0.yml
@@ -20,7 +20,7 @@ cache:
     maximumSize: 32768
     expireAfterAccess: 60000
   diskCache:
-    enabled: true
+    enabled: false
     directory: orebfuscator_cache
     maximumOpenFiles: 256
     deleteFilesAfterAccess: 172800000

--- a/orebfuscator-core/src/main/resources/config/config-1.18.0.yml
+++ b/orebfuscator-core/src/main/resources/config/config-1.18.0.yml
@@ -20,7 +20,7 @@ cache:
     maximumSize: 32768
     expireAfterAccess: 60000
   diskCache:
-    enabled: true
+    enabled: false
     directory: orebfuscator_cache
     maximumOpenFiles: 256
     deleteFilesAfterAccess: 172800000

--- a/orebfuscator-core/src/main/resources/config/config-1.20.3.yml
+++ b/orebfuscator-core/src/main/resources/config/config-1.20.3.yml
@@ -20,7 +20,7 @@ cache:
     maximumSize: 32768
     expireAfterAccess: 60000
   diskCache:
-    enabled: true
+    enabled: false
     directory: orebfuscator_cache
     maximumOpenFiles: 256
     deleteFilesAfterAccess: 172800000

--- a/orebfuscator-core/src/main/resources/config/config-1.21.9.yml
+++ b/orebfuscator-core/src/main/resources/config/config-1.21.9.yml
@@ -20,7 +20,7 @@ cache:
     maximumSize: 32768
     expireAfterAccess: 60000
   diskCache:
-    enabled: true
+    enabled: false
     directory: orebfuscator_cache
     maximumOpenFiles: 256
     deleteFilesAfterAccess: 172800000

--- a/orebfuscator-plugin/pom.xml
+++ b/orebfuscator-plugin/pom.xml
@@ -27,16 +27,11 @@
           <minimizeJar>true</minimizeJar>
           <filters>
             <filter>
-              <artifact>*:lz4-java</artifact>
-              <includes>
-                <include>**</include>
-              </includes>
-            </filter>
-            <filter>
               <artifact>*:*</artifact>
               <excludeDefaults>false</excludeDefaults>
               <includes>
                 <include>net/imprex/orebfuscator/**</include>
+                <include>dev/imprex/shaded/**</include>
               </includes>
             </filter>
           </filters>
@@ -46,16 +41,12 @@
               <shadedPattern>net.imprex.shaded.org.bstats</shadedPattern>
             </relocation>
             <relocation>
-              <pattern>org.joml</pattern>
-              <shadedPattern>net.imprex.shaded.org.joml</shadedPattern>
-            </relocation>
-            <relocation>
-              <pattern>net.jpountz</pattern>
-              <shadedPattern>net.imprex.shaded.net.jpountz</shadedPattern>
-            </relocation>
-            <relocation>
               <pattern>org.jetbrains</pattern>
               <shadedPattern>net.imprex.shaded.org.jetbrains</shadedPattern>
+            </relocation>
+            <relocation>
+              <pattern>org.jspecify</pattern>
+              <shadedPattern>net.imprex.shaded.org.jspecify</shadedPattern>
             </relocation>
           </relocations>
         </configuration>
@@ -92,18 +83,6 @@
       <scope>compile</scope>
     </dependency>
     <dependency>
-      <groupId>org.joml</groupId>
-      <artifactId>joml</artifactId>
-      <version>${dependency.joml.version}</version>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
-      <groupId>at.yawk.lz4</groupId>
-      <artifactId>lz4-java</artifactId>
-      <version>${dependency.lz4.version}</version>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
       <groupId>org.jetbrains</groupId>
       <artifactId>annotations</artifactId>
       <version>${dependency.jetannotations.version}</version>
@@ -122,24 +101,6 @@
       <artifactId>orebfuscator-core</artifactId>
       <version>${revision}</version>
       <scope>compile</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>com.google.guava</groupId>
-          <artifactId>guava</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.yaml</groupId>
-          <artifactId>snakeyaml</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.joml</groupId>
-          <artifactId>joml</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>at.yawk.lz4</groupId>
-          <artifactId>lz4-java</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
 
     <!-- Orebfuscator compatibility -->

--- a/orebfuscator-plugin/src/main/java/net/imprex/orebfuscator/Orebfuscator.java
+++ b/orebfuscator-plugin/src/main/java/net/imprex/orebfuscator/Orebfuscator.java
@@ -1,5 +1,6 @@
 package net.imprex.orebfuscator;
 
+import dev.imprex.orebfuscator.SystemMonitor;
 import dev.imprex.orebfuscator.UpdateSystem;
 import dev.imprex.orebfuscator.cache.AbstractRegionFileCache;
 import dev.imprex.orebfuscator.cache.ObfuscationCache;
@@ -44,6 +45,7 @@ public class Orebfuscator extends JavaPlugin implements Listener, OrebfuscatorCo
   private OrebfuscatorConfig config;
   private OrebfuscatorStatistics statistics;
   private OrebfuscatorExecutor executor;
+  private SystemMonitor systemMonitor;
 
   private BukkitWorldAccessorManager worldManager;
   private BukkitPlayerAccessorManager playerManager;
@@ -91,6 +93,7 @@ public class Orebfuscator extends JavaPlugin implements Listener, OrebfuscatorCo
 
       this.statistics = new OrebfuscatorStatistics(this.config, this.statisticsRegistry);
       this.executor = new OrebfuscatorExecutor(this);
+      this.systemMonitor = new SystemMonitor(this);
 
       this.chunkFactory = new ChunkFactory(this);
       this.obfuscationProcessor = new ObfuscationProcessor(this);
@@ -175,6 +178,11 @@ public class Orebfuscator extends JavaPlugin implements Listener, OrebfuscatorCo
   @Override
   public OrebfuscatorExecutor executor() {
     return executor;
+  }
+
+  @Override
+  public SystemMonitor systemMonitor() {
+    return systemMonitor;
   }
 
   @Override

--- a/orebfuscator-plugin/src/main/java/net/imprex/orebfuscator/OrebfuscatorCommand.java
+++ b/orebfuscator-plugin/src/main/java/net/imprex/orebfuscator/OrebfuscatorCommand.java
@@ -50,6 +50,7 @@ public class OrebfuscatorCommand implements CommandExecutor, TabCompleter {
       dumpFile.set("versions.nms", MinecraftVersion.nmsVersion());
       dumpFile.set("versions.server", Bukkit.getVersion());
       dumpFile.set("versions.bukkit", Bukkit.getBukkitVersion());
+      dumpFile.set("versions.vendor", Bukkit.getName());
       dumpFile.set("versions.protocolLib", ProtocolLibrary.getPlugin().toString());
 
       var plugins = dumpFile.createSection("plugins");


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- fix `/orebfuscator dump` command on spigot
- add version support policy to README
- disable disk cache by default

## How Has This Been Tested?
Tested with spigot/paper 1.16.5, 1.20.1 and 1.21.x

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
