### PR TITLE
[#475] Add ClientboundSetChunkCacheCenterPacket to respawn related packet list

### DIFF
--- a/orebfuscator-nms/orebfuscator-nms-v26_1/pom.xml
+++ b/orebfuscator-nms/orebfuscator-nms-v26_1/pom.xml
@@ -23,7 +23,7 @@
     <dependency>
       <groupId>org.spigotmc</groupId>
       <artifactId>spigot</artifactId>
-      <version>26.1-R0.1-SNAPSHOT</version>
+      <version>26.1.2-R0.1-SNAPSHOT</version>
       <scope>provided</scope>
     </dependency>
   </dependencies>

--- a/orebfuscator-plugin/src/main/java/net/imprex/orebfuscator/obfuscation/ObfuscationAsyncListener.java
+++ b/orebfuscator-plugin/src/main/java/net/imprex/orebfuscator/obfuscation/ObfuscationAsyncListener.java
@@ -1,5 +1,9 @@
 package net.imprex.orebfuscator.obfuscation;
 
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Stream;
+import org.jspecify.annotations.NullMarked;
 import com.comphenix.protocol.AsynchronousManager;
 import com.comphenix.protocol.PacketType;
 import com.comphenix.protocol.ProtocolLibrary;
@@ -11,16 +15,11 @@ import dev.imprex.orebfuscator.logging.LogLevel;
 import dev.imprex.orebfuscator.logging.OfcLogger;
 import dev.imprex.orebfuscator.obfuscation.ObfuscationPipeline;
 import dev.imprex.orebfuscator.statistics.InjectorStatistics;
-import java.util.List;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.stream.Stream;
 import net.imprex.orebfuscator.Orebfuscator;
 import net.imprex.orebfuscator.iterop.BukkitChunkPacketAccessor;
 import net.imprex.orebfuscator.iterop.BukkitPlayerAccessor;
 import net.imprex.orebfuscator.iterop.BukkitPlayerAccessorManager;
 import net.imprex.orebfuscator.iterop.BukkitWorldAccessor;
-import org.jspecify.annotations.NullMarked;
 
 @NullMarked
 public class ObfuscationAsyncListener extends PacketAdapter {
@@ -102,7 +101,7 @@ public class ObfuscationAsyncListener extends PacketAdapter {
         if (packet.isEmpty()) {
           future = CompletableFuture.completedFuture(null);
         } else {
-          OfcLogger.throttle(LogLevel.WARN, "Processing chunk packet async without an obfuscation future, that shouldn't happen!");
+          OfcLogger.throttle(LogLevel.DEBUG, "Processing chunk packet async without an obfuscation future");
           future = pipeline.request(world, player, packet, null).toCompletableFuture();
         }
       }

--- a/orebfuscator-plugin/src/main/java/net/imprex/orebfuscator/obfuscation/ObfuscationSyncListener.java
+++ b/orebfuscator-plugin/src/main/java/net/imprex/orebfuscator/obfuscation/ObfuscationSyncListener.java
@@ -28,6 +28,7 @@ public class ObfuscationSyncListener extends PacketAdapter {
       // 1.16.5
       PacketType.Play.Server.RESPAWN,
       PacketType.Play.Server.VIEW_DISTANCE,
+      PacketType.Play.Server.VIEW_CENTRE,
       PacketType.Play.Server.POSITION,
       PacketType.Play.Server.SPAWN_POSITION,
       PacketType.Play.Server.SERVER_DIFFICULTY,

--- a/orebfuscator-plugin/src/main/java/net/imprex/orebfuscator/obfuscation/ObfuscationSyncListener.java
+++ b/orebfuscator-plugin/src/main/java/net/imprex/orebfuscator/obfuscation/ObfuscationSyncListener.java
@@ -1,29 +1,26 @@
 package net.imprex.orebfuscator.obfuscation;
 
+import java.util.List;
+import java.util.stream.Stream;
+import org.jspecify.annotations.NullMarked;
 import com.comphenix.protocol.PacketType;
 import com.comphenix.protocol.ProtocolLibrary;
 import com.comphenix.protocol.ProtocolManager;
 import com.comphenix.protocol.events.PacketAdapter;
 import com.comphenix.protocol.events.PacketEvent;
 import dev.imprex.orebfuscator.PermissionRequirements;
-import dev.imprex.orebfuscator.logging.OfcLogger;
 import dev.imprex.orebfuscator.obfuscation.ObfuscationPipeline;
 import dev.imprex.orebfuscator.statistics.InjectorStatistics;
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Objects;
-import java.util.stream.Stream;
 import net.imprex.orebfuscator.Orebfuscator;
 import net.imprex.orebfuscator.iterop.BukkitChunkPacketAccessor;
 import net.imprex.orebfuscator.iterop.BukkitPlayerAccessor;
 import net.imprex.orebfuscator.iterop.BukkitPlayerAccessorManager;
 import net.imprex.orebfuscator.iterop.BukkitWorldAccessor;
-import org.jspecify.annotations.NullMarked;
 
 @NullMarked
 public class ObfuscationSyncListener extends PacketAdapter {
 
+  @SuppressWarnings("deprecation")
   public static final List<PacketType> PACKET_TYPES_RESPAWN = Stream.of(
       // 1.16.5
       PacketType.Play.Server.RESPAWN,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Add missing `ClientboundSetChunkCacheCenterPacket` to respawn related packet list in sync injector.

## Related Issue
#475 

## How Has This Been Tested?
Not tested

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
