### PR TITLE
[#489] Fix folia support post 26.1

### DIFF
--- a/orebfuscator-bukkit/orebfuscator-bukkit-compatibility/orebfuscator-bukkit-compatibility-folia/src/main/java/net/imprex/orebfuscator/compatibility/folia/FoliaCompatibilityLayer.java
+++ b/orebfuscator-bukkit/orebfuscator-bukkit-compatibility/orebfuscator-bukkit-compatibility-folia/src/main/java/net/imprex/orebfuscator/compatibility/folia/FoliaCompatibilityLayer.java
@@ -1,10 +1,17 @@
 package net.imprex.orebfuscator.compatibility.folia;
 
 import dev.imprex.orebfuscator.config.api.Config;
+import dev.imprex.orebfuscator.interop.ChunkAccessor;
+import net.imprex.orebfuscator.OrebfuscatorNms;
 import net.imprex.orebfuscator.compatibility.CompatibilityLayer;
 import net.imprex.orebfuscator.compatibility.CompatibilityScheduler;
+import org.bukkit.World;
 import org.bukkit.plugin.Plugin;
+import org.jspecify.annotations.NullMarked;
 
+import java.util.concurrent.CompletableFuture;
+
+@NullMarked
 public class FoliaCompatibilityLayer implements CompatibilityLayer {
 
   private static final Class<?> TICK_THREAD_CLASS = getTickThreadClass();
@@ -31,5 +38,13 @@ public class FoliaCompatibilityLayer implements CompatibilityLayer {
   @Override
   public CompatibilityScheduler getScheduler() {
     return this.scheduler;
+  }
+
+  @Override
+  public CompletableFuture<ChunkAccessor> getChunkFuture(World world, int chunkX, int chunkZ) {
+    return world.getChunkAtAsync(chunkX, chunkZ).thenApply(unused -> {
+      var chunk = OrebfuscatorNms.getChunkNow(world, chunkX, chunkZ);
+      return ChunkAccessor.ofNullable(chunk);
+    });
   }
 }

--- a/orebfuscator-bukkit/orebfuscator-bukkit-compatibility/orebfuscator-bukkit-compatibility-paper/src/main/java/net/imprex/orebfuscator/compatibility/paper/PaperCompatibilityLayer.java
+++ b/orebfuscator-bukkit/orebfuscator-bukkit-compatibility/orebfuscator-bukkit-compatibility-paper/src/main/java/net/imprex/orebfuscator/compatibility/paper/PaperCompatibilityLayer.java
@@ -1,28 +1,27 @@
 package net.imprex.orebfuscator.compatibility.paper;
 
 import dev.imprex.orebfuscator.config.api.Config;
-import net.imprex.orebfuscator.compatibility.CompatibilityLayer;
-import net.imprex.orebfuscator.compatibility.CompatibilityScheduler;
-import net.imprex.orebfuscator.compatibility.spigot.SpigotScheduler;
+import dev.imprex.orebfuscator.interop.ChunkAccessor;
+import net.imprex.orebfuscator.OrebfuscatorNms;
+import net.imprex.orebfuscator.compatibility.spigot.SpigotCompatibilityLayer;
+import org.bukkit.World;
 import org.bukkit.plugin.Plugin;
+import org.jspecify.annotations.NullMarked;
 
-public class PaperCompatibilityLayer implements CompatibilityLayer {
+import java.util.concurrent.CompletableFuture;
 
-  private final Thread mainThread = Thread.currentThread();
-
-  private final SpigotScheduler scheduler;
+@NullMarked
+public class PaperCompatibilityLayer extends SpigotCompatibilityLayer {
 
   public PaperCompatibilityLayer(Plugin plugin, Config config) {
-    this.scheduler = new SpigotScheduler(plugin);
+    super(plugin, config);
   }
 
   @Override
-  public boolean isGameThread() {
-    return Thread.currentThread() == this.mainThread;
-  }
-
-  @Override
-  public CompatibilityScheduler getScheduler() {
-    return this.scheduler;
+  public CompletableFuture<ChunkAccessor> getChunkFuture(World world, int chunkX, int chunkZ) {
+    return world.getChunkAtAsync(chunkX, chunkZ).thenApply(unused -> {
+      var chunk = OrebfuscatorNms.getChunkNow(world, chunkX, chunkZ);
+      return ChunkAccessor.ofNullable(chunk);
+    });
   }
 }

--- a/orebfuscator-bukkit/orebfuscator-bukkit-compatibility/orebfuscator-bukkit-compatibility-spigot/src/main/java/net/imprex/orebfuscator/compatibility/spigot/SpigotCompatibilityLayer.java
+++ b/orebfuscator-bukkit/orebfuscator-bukkit-compatibility/orebfuscator-bukkit-compatibility-spigot/src/main/java/net/imprex/orebfuscator/compatibility/spigot/SpigotCompatibilityLayer.java
@@ -1,10 +1,17 @@
 package net.imprex.orebfuscator.compatibility.spigot;
 
 import dev.imprex.orebfuscator.config.api.Config;
+import dev.imprex.orebfuscator.interop.ChunkAccessor;
+import net.imprex.orebfuscator.OrebfuscatorNms;
 import net.imprex.orebfuscator.compatibility.CompatibilityLayer;
 import net.imprex.orebfuscator.compatibility.CompatibilityScheduler;
+import org.bukkit.World;
 import org.bukkit.plugin.Plugin;
+import org.jspecify.annotations.NullMarked;
 
+import java.util.concurrent.CompletableFuture;
+
+@NullMarked
 public class SpigotCompatibilityLayer implements CompatibilityLayer {
 
   private final Thread mainThread = Thread.currentThread();
@@ -23,5 +30,11 @@ public class SpigotCompatibilityLayer implements CompatibilityLayer {
   @Override
   public CompatibilityScheduler getScheduler() {
     return this.scheduler;
+  }
+
+  @Override
+  public CompletableFuture<ChunkAccessor> getChunkFuture(World world, int chunkX, int chunkZ) {
+    return OrebfuscatorNms.getChunkFuture(world, chunkX, chunkZ)
+        .thenApply(ChunkAccessor::ofNullable);
   }
 }

--- a/orebfuscator-bukkit/orebfuscator-bukkit-compatibility/src/main/java/net/imprex/orebfuscator/OrebfuscatorCompatibility.java
+++ b/orebfuscator-bukkit/orebfuscator-bukkit-compatibility/src/main/java/net/imprex/orebfuscator/OrebfuscatorCompatibility.java
@@ -1,10 +1,14 @@
 package net.imprex.orebfuscator;
 
 import dev.imprex.orebfuscator.config.api.Config;
+import dev.imprex.orebfuscator.interop.ChunkAccessor;
 import dev.imprex.orebfuscator.logging.OfcLogger;
 import java.lang.reflect.Constructor;
+import java.util.concurrent.CompletableFuture;
+
 import net.imprex.orebfuscator.compatibility.CompatibilityLayer;
 import net.imprex.orebfuscator.util.ServerVersion;
+import org.bukkit.World;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.Plugin;
 
@@ -48,6 +52,10 @@ public class OrebfuscatorCompatibility {
 
   public static void runAsyncNow(Runnable runnable) {
     instance.getScheduler().runAsyncNow(runnable);
+  }
+
+  public static CompletableFuture<ChunkAccessor> getChunkFuture(World world, int chunkX, int chunkZ) {
+    return instance.getChunkFuture(world, chunkX, chunkZ);
   }
 
   public static void close() {

--- a/orebfuscator-bukkit/orebfuscator-bukkit-compatibility/src/main/java/net/imprex/orebfuscator/compatibility/CompatibilityLayer.java
+++ b/orebfuscator-bukkit/orebfuscator-bukkit-compatibility/src/main/java/net/imprex/orebfuscator/compatibility/CompatibilityLayer.java
@@ -1,8 +1,17 @@
 package net.imprex.orebfuscator.compatibility;
 
+import dev.imprex.orebfuscator.interop.ChunkAccessor;
+import org.bukkit.World;
+import org.jspecify.annotations.NullMarked;
+
+import java.util.concurrent.CompletableFuture;
+
+@NullMarked
 public interface CompatibilityLayer {
 
   boolean isGameThread();
 
   CompatibilityScheduler getScheduler();
+
+  CompletableFuture<ChunkAccessor> getChunkFuture(World world, int chunkX, int chunkZ);
 }

--- a/orebfuscator-bukkit/src/main/java/net/imprex/orebfuscator/iterop/BukkitWorldAccessor.java
+++ b/orebfuscator-bukkit/src/main/java/net/imprex/orebfuscator/iterop/BukkitWorldAccessor.java
@@ -14,6 +14,7 @@ import java.util.Arrays;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import net.imprex.orebfuscator.Orebfuscator;
+import net.imprex.orebfuscator.OrebfuscatorCompatibility;
 import net.imprex.orebfuscator.OrebfuscatorNms;
 import net.imprex.orebfuscator.util.MinecraftVersion;
 import org.bukkit.World;
@@ -158,8 +159,7 @@ public class BukkitWorldAccessor implements WorldAccessor {
       var chunk = neighborChunks != null ? neighborChunks[index] : null;
 
       if (ChunkAccessor.isNullOrEmpty(chunk)) {
-        futures[index] = OrebfuscatorNms.getChunkFuture(world, chunkX, chunkZ)
-            .thenApply(ChunkAccessor::ofNullable);
+        futures[index] = OrebfuscatorCompatibility.getChunkFuture(world, chunkX, chunkZ);
       } else {
         futures[index] = CompletableFuture.completedFuture(chunk);
       }


### PR DESCRIPTION
## Description
Fixed support for folia versions post minecraft 26.1.

## Related Issue
closes #489, #492 

## How Has This Been Tested?
Successfully tested with the latest Spigot, Paper and Folia builds

## Types of Changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
